### PR TITLE
Add verbose option to reply command for enhanced context output

### DIFF
--- a/src/toady/reply_service.py
+++ b/src/toady/reply_service.py
@@ -47,7 +47,17 @@ class ReplyService:
             request: ReplyRequest object containing all necessary parameters.
 
         Returns:
-            Dictionary containing reply information including URL and ID.
+            Dictionary containing comprehensive reply information including:
+            - reply_id: The unique ID of the posted reply
+            - reply_url: Direct URL to view the reply on GitHub
+            - comment_id: The ID of the comment being replied to
+            - created_at: Timestamp when the reply was created
+            - author: Username of the reply author
+            - pr_number: Pull request number the comment belongs to
+            - pr_title: Title of the pull request
+            - thread_url: URL to the entire review thread
+            - body_preview: First 100 characters of the reply body
+            - parent_comment_author: Author of the comment being replied to
 
         Raises:
             ReplyServiceError: If the reply fails to post.
@@ -86,14 +96,25 @@ class ReplyService:
             result = self.github_service.run_gh_command(args)
             response_data = json.loads(result.stdout)
 
-            # Extract relevant information from the response
+            # Extract comprehensive information from the response
             reply_info = {
                 "reply_id": str(response_data.get("id", "")),
                 "reply_url": response_data.get("html_url", ""),
                 "comment_id": request.comment_id,
                 "created_at": response_data.get("created_at", ""),
                 "author": response_data.get("user", {}).get("login", ""),
+                "body_preview": request.reply_body[:100]
+                + ("..." if len(request.reply_body) > 100 else ""),
             }
+
+            # Extract additional context if available
+            if "pull_request_review_id" in response_data:
+                reply_info["review_id"] = str(response_data["pull_request_review_id"])
+
+            # Try to get parent comment info for context
+            parent_info = self._get_parent_comment_info(owner, repo, request.comment_id)
+            if parent_info:
+                reply_info.update(parent_info)
 
             return reply_info
 
@@ -157,3 +178,89 @@ class ReplyService:
 
         except (GitHubAPIError, json.JSONDecodeError, KeyError):
             return False
+
+    def _get_parent_comment_info(
+        self, owner: str, repo: str, comment_id: str
+    ) -> Optional[Dict[str, str]]:
+        """Get information about the parent comment for additional context.
+
+        Args:
+            owner: Repository owner.
+            repo: Repository name.
+            comment_id: Comment ID to get info for.
+
+        Returns:
+            Dictionary with parent comment info or None if not available.
+        """
+        try:
+            # Query the specific comment to get context
+            endpoint = f"repos/{owner}/{repo}/pulls/comments/{comment_id}"
+            args = ["api", endpoint, "--header", "Accept: application/vnd.github+json"]
+
+            result = self.github_service.run_gh_command(args)
+            data = json.loads(result.stdout)
+
+            parent_info = {}
+
+            # Get PR information from the comment
+            if "pull_request_url" in data:
+                pr_url = data["pull_request_url"]
+                pr_number = pr_url.split("/")[-1]
+                parent_info["pr_number"] = pr_number
+
+                # Try to get PR title
+                pr_info = self._get_pr_info(owner, repo, pr_number)
+                if pr_info:
+                    parent_info["pr_title"] = pr_info.get("title", "")
+                    parent_info["pr_url"] = pr_info.get("html_url", "")
+
+            # Get parent comment author
+            if "user" in data and "login" in data["user"]:
+                parent_info["parent_comment_author"] = data["user"]["login"]
+
+            # Get thread URL if available
+            if "html_url" in data:
+                # Convert comment URL to thread URL
+                comment_url = data["html_url"]
+                thread_url = (
+                    comment_url.split("#")[0]
+                    + "#pullrequestreview-"
+                    + str(data.get("pull_request_review_id", ""))
+                )
+                if data.get("pull_request_review_id"):
+                    parent_info["thread_url"] = thread_url
+
+            return parent_info if parent_info else None
+
+        except (GitHubAPIError, json.JSONDecodeError, KeyError):
+            # Don't fail the whole operation if we can't get parent info
+            return None
+
+    def _get_pr_info(
+        self, owner: str, repo: str, pr_number: str
+    ) -> Optional[Dict[str, str]]:
+        """Get basic PR information.
+
+        Args:
+            owner: Repository owner.
+            repo: Repository name.
+            pr_number: Pull request number.
+
+        Returns:
+            Dictionary with PR info or None if not available.
+        """
+        try:
+            endpoint = f"repos/{owner}/{repo}/pulls/{pr_number}"
+            args = ["api", endpoint, "--header", "Accept: application/vnd.github+json"]
+
+            result = self.github_service.run_gh_command(args)
+            data = json.loads(result.stdout)
+
+            return {
+                "title": data.get("title", ""),
+                "html_url": data.get("html_url", ""),
+                "state": data.get("state", ""),
+            }
+
+        except (GitHubAPIError, json.JSONDecodeError, KeyError):
+            return None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1007,6 +1007,168 @@ class TestReplyCommand:
         )
         assert "⚠️  Note: Reply contains very repetitive content" in result.output
 
+    @patch("toady.cli.ReplyService")
+    def test_reply_with_verbose_mode_pretty(
+        self, mock_service_class: Mock, runner: CliRunner
+    ) -> None:
+        """Test reply with verbose mode in pretty format."""
+        mock_service = Mock()
+        mock_service.post_reply.return_value = {
+            "reply_id": "987654321",
+            "reply_url": "https://github.com/owner/repo/pull/1#discussion_r987654321",
+            "comment_id": "123456789",
+            "created_at": "2023-01-01T12:00:00Z",
+            "author": "testuser",
+            "pr_number": "42",
+            "pr_title": "Add awesome feature",
+            "parent_comment_author": "reviewer123",
+            "body_preview": "This is a test reply that demonstrates...",
+            "thread_url": "https://github.com/owner/repo/pull/42#pullrequestreview-123456",
+        }
+        mock_service_class.return_value = mock_service
+
+        result = runner.invoke(
+            cli,
+            [
+                "reply",
+                "--comment-id",
+                "123456789",
+                "--body",
+                "This is a test reply that demonstrates the verbose feature",
+                "--pretty",
+                "--verbose",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "✅ Reply posted successfully" in result.output
+        assert "📋 Reply Details:" in result.output
+        assert "Pull Request: #42 - Add awesome feature" in result.output
+        assert "Replying to: @reviewer123" in result.output
+        assert "Your reply: This is a test reply that demonstrates..." in result.output
+        assert "Thread URL:" in result.output
+        assert "Posted at: 2023-01-01T12:00:00Z" in result.output
+        assert "Posted by: @testuser" in result.output
+
+    @patch("toady.cli.ReplyService")
+    def test_reply_with_verbose_mode_json(
+        self, mock_service_class: Mock, runner: CliRunner
+    ) -> None:
+        """Test reply with verbose mode in JSON format."""
+        mock_service = Mock()
+        mock_service.post_reply.return_value = {
+            "reply_id": "987654321",
+            "reply_url": "https://github.com/owner/repo/pull/1#discussion_r987654321",
+            "comment_id": "123456789",
+            "created_at": "2023-01-01T12:00:00Z",
+            "author": "testuser",
+            "pr_number": "42",
+            "pr_title": "Add awesome feature",
+            "parent_comment_author": "reviewer123",
+            "body_preview": "Test reply",
+            "thread_url": "https://github.com/owner/repo/pull/42#pullrequestreview-123456",
+            "review_id": "123456",
+        }
+        mock_service_class.return_value = mock_service
+
+        result = runner.invoke(
+            cli,
+            [
+                "reply",
+                "--comment-id",
+                "123456789",
+                "--body",
+                "Test reply",
+                "--verbose",
+            ],
+        )
+        assert result.exit_code == 0
+
+        output = json.loads(result.output)
+        assert output["reply_posted"] is True
+        assert output["pr_number"] == "42"
+        assert output["pr_title"] == "Add awesome feature"
+        assert output["parent_comment_author"] == "reviewer123"
+        assert output["body_preview"] == "Test reply"
+        assert (
+            output["thread_url"]
+            == "https://github.com/owner/repo/pull/42#pullrequestreview-123456"
+        )
+        assert output["review_id"] == "123456"
+        assert output["verbose"] is True
+
+    @patch("toady.cli.ReplyService")
+    def test_reply_with_partial_metadata(
+        self, mock_service_class: Mock, runner: CliRunner
+    ) -> None:
+        """Test reply when only partial metadata is available."""
+        mock_service = Mock()
+        # Return minimal info (simulating when parent info fetch fails)
+        mock_service.post_reply.return_value = {
+            "reply_id": "987654321",
+            "reply_url": "https://github.com/owner/repo/pull/1#discussion_r987654321",
+            "comment_id": "123456789",
+            "created_at": "2023-01-01T12:00:00Z",
+            "author": "testuser",
+            "body_preview": "Test reply",
+        }
+        mock_service_class.return_value = mock_service
+
+        result = runner.invoke(
+            cli,
+            [
+                "reply",
+                "--comment-id",
+                "123456789",
+                "--body",
+                "Test reply",
+                "--pretty",
+                "--verbose",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "✅ Reply posted successfully" in result.output
+        assert "📋 Reply Details:" in result.output
+        # Should not show PR info if not available
+        assert "Pull Request:" not in result.output
+        assert "Replying to:" not in result.output
+        # Should still show available info
+        assert "Your reply: Test reply" in result.output
+        assert "Posted at: 2023-01-01T12:00:00Z" in result.output
+
+    @patch("toady.cli.ReplyService")
+    def test_reply_verbose_short_flag(
+        self, mock_service_class: Mock, runner: CliRunner
+    ) -> None:
+        """Test reply with -v short flag for verbose."""
+        mock_service = Mock()
+        mock_service.post_reply.return_value = {
+            "reply_id": "987654321",
+            "reply_url": "https://github.com/owner/repo/pull/1#discussion_r987654321",
+            "comment_id": "123456789",
+            "created_at": "2023-01-01T12:00:00Z",
+            "author": "testuser",
+            "pr_number": "42",
+            "pr_title": "Test PR",
+        }
+        mock_service_class.return_value = mock_service
+
+        result = runner.invoke(
+            cli,
+            ["reply", "--comment-id", "123456789", "--body", "Test", "--pretty", "-v"],
+        )
+        assert result.exit_code == 0
+        assert "📋 Reply Details:" in result.output
+        assert "Pull Request: #42 - Test PR" in result.output
+
+    def test_reply_help_shows_verbose_option(self, runner: CliRunner) -> None:
+        """Test that help text mentions the verbose option."""
+        result = runner.invoke(cli, ["reply", "--help"])
+        assert result.exit_code == 0
+        assert "--verbose" in result.output
+        assert "-v" in result.output
+        assert "Show additional details" in result.output
+        assert "Use --verbose/-v flag" in result.output
+
 
 class TestResolveCommand:
     """Test the resolve command."""

--- a/tests/test_reply_service.py
+++ b/tests/test_reply_service.py
@@ -46,7 +46,12 @@ class TestReplyService:
                 "user": {"login": "testuser"},
             }
         )
-        mock_github_service.run_gh_command.return_value = mock_response
+
+        # Set up the responses: first for posting reply, then parent info fails
+        mock_github_service.run_gh_command.side_effect = [
+            mock_response,  # post_reply call
+            GitHubAPIError("404 Not Found"),  # _get_parent_comment_info fails
+        ]
 
         mock_get_repo_info.return_value = ("owner", "repo")
 
@@ -71,7 +76,9 @@ class TestReplyService:
             "--header",
             "Accept: application/vnd.github+json",
         ]
-        mock_github_service.run_gh_command.assert_called_once_with(expected_args)
+        assert (
+            mock_github_service.run_gh_command.call_args_list[0][0][0] == expected_args
+        )
 
     def test_post_reply_with_explicit_params(self) -> None:
         """Test reply posting with explicitly provided parameters."""
@@ -85,7 +92,12 @@ class TestReplyService:
                 "user": {"login": "reviewer"},
             }
         )
-        mock_github_service.run_gh_command.return_value = mock_response
+
+        # Set up the responses: first for posting reply, then parent info fails
+        mock_github_service.run_gh_command.side_effect = [
+            mock_response,  # post_reply call
+            GitHubAPIError("404 Not Found"),  # _get_parent_comment_info fails
+        ]
 
         service = ReplyService(mock_github_service)
         request = ReplyRequest(
@@ -110,7 +122,9 @@ class TestReplyService:
             "--header",
             "Accept: application/vnd.github+json",
         ]
-        mock_github_service.run_gh_command.assert_called_once_with(expected_args)
+        assert (
+            mock_github_service.run_gh_command.call_args_list[0][0][0] == expected_args
+        )
 
     @patch.object(ReplyService, "_get_repository_info")
     def test_post_reply_comment_not_found(self, mock_get_repo_info: Mock) -> None:
@@ -245,6 +259,186 @@ class TestReplyService:
 
         assert exists is False
 
+    def test_post_reply_with_parent_info(self) -> None:
+        """Test posting reply with parent comment information."""
+        mock_github_service = Mock(spec=GitHubService)
+
+        # Mock main reply response
+        reply_response = Mock()
+        reply_response.stdout = json.dumps(
+            {
+                "id": 987654321,
+                "html_url": "https://github.com/owner/repo/pull/1#discussion_r987654321",
+                "created_at": "2023-01-01T12:00:00Z",
+                "user": {"login": "testuser"},
+                "pull_request_review_id": 111222333,
+            }
+        )
+
+        # Mock parent comment response
+        parent_response = Mock()
+        parent_response.stdout = json.dumps(
+            {
+                "id": 123456789,
+                "user": {"login": "reviewer123"},
+                "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/42",
+                "pull_request_review_id": 111222333,
+                "html_url": "https://github.com/owner/repo/pull/42#discussion_r123456789",
+            }
+        )
+
+        # Mock PR info response
+        pr_response = Mock()
+        pr_response.stdout = json.dumps(
+            {
+                "number": 42,
+                "title": "Add awesome feature",
+                "html_url": "https://github.com/owner/repo/pull/42",
+                "state": "open",
+            }
+        )
+
+        # Set up responses in order
+        mock_github_service.run_gh_command.side_effect = [
+            reply_response,  # post_reply call
+            parent_response,  # _get_parent_comment_info call
+            pr_response,  # _get_pr_info call
+        ]
+        mock_github_service.get_current_repo.return_value = "owner/repo"
+
+        service = ReplyService(mock_github_service)
+        request = ReplyRequest(
+            comment_id="123456789", reply_body="Test reply with context"
+        )
+        result = service.post_reply(request)
+
+        assert result["reply_id"] == "987654321"
+        assert result["pr_number"] == "42"
+        assert result["pr_title"] == "Add awesome feature"
+        assert result["parent_comment_author"] == "reviewer123"
+        assert (
+            result["thread_url"]
+            == "https://github.com/owner/repo/pull/42#pullrequestreview-111222333"
+        )
+        assert result["body_preview"] == "Test reply with context"
+
+    def test_post_reply_parent_info_failure(self) -> None:
+        """Test posting reply when parent info fetch fails."""
+        mock_github_service = Mock(spec=GitHubService)
+
+        # Mock main reply response
+        reply_response = Mock()
+        reply_response.stdout = json.dumps(
+            {
+                "id": 987654321,
+                "html_url": "https://github.com/owner/repo/pull/1#discussion_r987654321",
+                "created_at": "2023-01-01T12:00:00Z",
+                "user": {"login": "testuser"},
+            }
+        )
+
+        # Mock parent comment failure
+        mock_github_service.run_gh_command.side_effect = [
+            reply_response,  # post_reply succeeds
+            GitHubAPIError("404 Not Found"),  # parent info fails
+        ]
+        mock_github_service.get_current_repo.return_value = "owner/repo"
+
+        service = ReplyService(mock_github_service)
+        request = ReplyRequest(comment_id="123456789", reply_body="Test reply")
+        result = service.post_reply(request)
+
+        # Should still succeed, just without parent info
+        assert result["reply_id"] == "987654321"
+        assert "pr_number" not in result
+        assert "parent_comment_author" not in result
+
+    def test_get_parent_comment_info_success(self) -> None:
+        """Test getting parent comment information."""
+        mock_github_service = Mock(spec=GitHubService)
+
+        # Mock comment response
+        comment_response = Mock()
+        comment_response.stdout = json.dumps(
+            {
+                "id": 123456789,
+                "user": {"login": "reviewer123"},
+                "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/42",
+                "pull_request_review_id": 111222333,
+                "html_url": "https://github.com/owner/repo/pull/42#discussion_r123456789",
+            }
+        )
+
+        # Mock PR response
+        pr_response = Mock()
+        pr_response.stdout = json.dumps(
+            {
+                "number": 42,
+                "title": "Test PR",
+                "html_url": "https://github.com/owner/repo/pull/42",
+                "state": "open",
+            }
+        )
+
+        mock_github_service.run_gh_command.side_effect = [comment_response, pr_response]
+
+        service = ReplyService(mock_github_service)
+        result = service._get_parent_comment_info("owner", "repo", "123456789")
+
+        assert result is not None
+        assert result["pr_number"] == "42"
+        assert result["pr_title"] == "Test PR"
+        assert result["parent_comment_author"] == "reviewer123"
+        assert "thread_url" in result
+
+    def test_get_pr_info_success(self) -> None:
+        """Test getting PR information."""
+        mock_github_service = Mock(spec=GitHubService)
+
+        pr_response = Mock()
+        pr_response.stdout = json.dumps(
+            {
+                "number": 42,
+                "title": "Amazing feature",
+                "html_url": "https://github.com/owner/repo/pull/42",
+                "state": "open",
+            }
+        )
+
+        mock_github_service.run_gh_command.return_value = pr_response
+
+        service = ReplyService(mock_github_service)
+        result = service._get_pr_info("owner", "repo", "42")
+
+        assert result is not None
+        assert result["title"] == "Amazing feature"
+        assert result["html_url"] == "https://github.com/owner/repo/pull/42"
+        assert result["state"] == "open"
+
+    def test_post_reply_long_body_preview(self) -> None:
+        """Test that body preview is truncated for long replies."""
+        mock_github_service = Mock(spec=GitHubService)
+
+        reply_response = Mock()
+        reply_response.stdout = json.dumps(
+            {
+                "id": 987654321,
+                "html_url": "https://github.com/owner/repo/pull/1#discussion_r987654321",
+                "created_at": "2023-01-01T12:00:00Z",
+                "user": {"login": "testuser"},
+            }
+        )
+
+        mock_github_service.run_gh_command.return_value = reply_response
+        mock_github_service.get_current_repo.return_value = "owner/repo"
+
+        service = ReplyService(mock_github_service)
+        long_body = "x" * 150  # Body longer than 100 chars
+        request = ReplyRequest(comment_id="123456789", reply_body=long_body)
+        result = service.post_reply(request)
+
+        assert result["body_preview"] == "x" * 100 + "..."
+
 
 class TestReplyServiceExceptions:
     """Test reply service exception hierarchy."""
@@ -279,7 +473,12 @@ class TestReplyServiceIntegration:
                 "user": {"login": "testuser"},
             }
         )
-        mock_github_service.run_gh_command.return_value = mock_response
+
+        # Set up the responses: first for posting reply, then parent info fails
+        mock_github_service.run_gh_command.side_effect = [
+            mock_response,  # post_reply call
+            GitHubAPIError("404 Not Found"),  # _get_parent_comment_info fails
+        ]
 
         service = ReplyService(mock_github_service)
         special_body = (
@@ -307,7 +506,9 @@ class TestReplyServiceIntegration:
             "--header",
             "Accept: application/vnd.github+json",
         ]
-        mock_github_service.run_gh_command.assert_called_once_with(expected_args)
+        assert (
+            mock_github_service.run_gh_command.call_args_list[0][0][0] == expected_args
+        )
 
     def test_post_reply_large_body(self) -> None:
         """Test reply posting with large body content."""
@@ -321,7 +522,12 @@ class TestReplyServiceIntegration:
                 "user": {"login": "testuser"},
             }
         )
-        mock_github_service.run_gh_command.return_value = mock_response
+
+        # Set up the responses: first for posting reply, then parent info fails
+        mock_github_service.run_gh_command.side_effect = [
+            mock_response,  # post_reply call
+            GitHubAPIError("404 Not Found"),  # _get_parent_comment_info fails
+        ]
 
         service = ReplyService(mock_github_service)
         large_body = "A" * 5000  # Large but reasonable reply
@@ -347,4 +553,6 @@ class TestReplyServiceIntegration:
             "--header",
             "Accept: application/vnd.github+json",
         ]
-        mock_github_service.run_gh_command.assert_called_once_with(expected_args)
+        assert (
+            mock_github_service.run_gh_command.call_args_list[0][0][0] == expected_args
+        )


### PR DESCRIPTION
- Introduced a new --verbose/-v flag to the reply command, allowing users to view additional details about the reply and its context.
- Updated the reply function to include verbose output, displaying information such as PR title, parent comment author, and thread details.
- Enhanced the ReplyService to fetch and return comprehensive reply information, including optional fields like PR number and body preview.
- Added tests to validate the new verbose functionality in both pretty and JSON output formats, ensuring robust coverage for various scenarios.