### PR TITLE
Add support for additional GitHub node ID formats and enhance validation

### DIFF
--- a/.taskmaster/docs/branch-mapping.txt
+++ b/.taskmaster/docs/branch-mapping.txt
@@ -46,3 +46,8 @@ Task 12.1: tony/bur-67-task-121-configure-setuppypyprojecttoml-with-metadata-and
 Task 12.2: tony/bur-68-task-122-create-distribution-files-and-test-packaging
 Task 12.3: tony/bur-69-task-123-test-installation-in-clean-environments-and
 Task 12.4: tony/bur-70-task-124-publish-to-testpypi-and-then-pypi-with
+Task 13: tony/bur-71-add-comprehensive-id-format-support-for-all-github-node-id
+Task 14: tony/bur-72-validate-graphql-schemas-against-current-github-api
+Task 15: tony/bur-73-implement-graphql-mutations-for-replying-to-review-comments
+Task 16: tony/bur-74-add-all-flag-to-resolve-all-unresolved-threads-at-once
+Task 17: tony/bur-75-add-dry-run-mode-to-preview-actions-before-execution

--- a/src/toady/cli.py
+++ b/src/toady/cli.py
@@ -279,7 +279,7 @@ def _validate_reply_args(comment_id: str, body: str) -> Tuple[str, str]:
                 "Comment ID must be a positive integer",
                 param_hint="--comment-id",
             )
-    elif comment_id.startswith("IC_"):
+    elif comment_id.startswith(("IC_", "PRRC_")):
         # GitHub node ID validation (more specific)
         if len(comment_id) < 10:  # More realistic minimum length
             raise click.BadParameter(
@@ -291,8 +291,11 @@ def _validate_reply_args(comment_id: str, body: str) -> Tuple[str, str]:
                 "GitHub node ID appears too long to be valid (maximum 100 characters)",
                 param_hint="--comment-id",
             )
-        # Check for valid base64-like characters after IC_
-        node_id_part = comment_id[3:]  # Remove "IC_" prefix
+        # Check for valid base64-like characters after prefix (IC_ or PRRC_)
+        if comment_id.startswith("IC_"):
+            node_id_part = comment_id[3:]  # Remove "IC_" prefix
+        else:  # PRRC_
+            node_id_part = comment_id[5:]  # Remove "PRRC_" prefix
         if not all(c.isalnum() or c in "-_=" for c in node_id_part):
             raise click.BadParameter(
                 "GitHub node ID contains invalid characters. Should only contain "
@@ -302,7 +305,7 @@ def _validate_reply_args(comment_id: str, body: str) -> Tuple[str, str]:
     else:
         raise click.BadParameter(
             "Comment ID must be numeric (e.g., 123456789) or a "
-            "GitHub node ID starting with 'IC_' (e.g., IC_kwDOABcD12MAAAABcDE3fg)",
+            "GitHub node ID starting with 'IC_' or 'PRRC_'",
             param_hint="--comment-id",
         )
 
@@ -432,7 +435,7 @@ def _build_json_reply(
     "--comment-id",
     required=True,
     type=str,
-    help="GitHub comment ID (numeric ID or node ID starting with IC_)",
+    help="GitHub comment ID (numeric ID or node ID starting with IC_/PRRC_)",
     metavar="ID",
 )
 @click.option(
@@ -460,7 +463,7 @@ def reply(
     """Post a reply to a specific review comment.
 
     Reply to comments using either numeric IDs (e.g., 123456789) or
-    GitHub node IDs (e.g., IC_kwDOABcD12MAAAABcDE3fg).
+    GitHub node IDs for issue comments (IC_) or review comments (PRRC_).
 
     Use --verbose/-v flag to show additional context including the PR title,
     parent comment author, and thread details.
@@ -471,7 +474,7 @@ def reply(
 
         toady reply --comment-id IC_kwDOABcD12MAAAABcDE3fg --body "Good catch!"
 
-        toady reply --comment-id 123456789 --body "Thanks for the review" --pretty
+        toady reply --comment-id PRRC_kwDOO3WQIc5_Pnh_ --body "Thanks for the review"
 
         toady reply --comment-id 123456789 --body "Updated per feedback" --pretty -v
     """
@@ -641,7 +644,7 @@ def reply(
     "--thread-id",
     required=True,
     type=str,
-    help="GitHub thread ID (numeric ID or node ID starting with PRT_)",
+    help="GitHub thread ID (numeric ID or node ID starting with PRT_/PRRT_)",
     metavar="ID",
 )
 @click.option(
@@ -659,13 +662,15 @@ def resolve(ctx: click.Context, thread_id: str, undo: bool, pretty: bool) -> Non
     """Mark a review thread as resolved or unresolved.
 
     Resolve or unresolve review threads using either numeric IDs or
-    GitHub node IDs (e.g., PRT_kwDOABcD12MAAAABcDE3fg).
+    GitHub node IDs for threads (PRT_) or review threads (PRRT_).
 
     Examples:
 
         toady resolve --thread-id 123456789
 
         toady resolve --thread-id PRT_kwDOABcD12MAAAABcDE3fg --undo
+
+        toady resolve --thread-id PRRT_kwDOO3WQIc5RvXMO
 
         toady resolve --thread-id 123456789 --pretty
     """
@@ -675,15 +680,15 @@ def resolve(ctx: click.Context, thread_id: str, undo: bool, pretty: bool) -> Non
         raise click.BadParameter("Thread ID cannot be empty", param_hint="--thread-id")
 
     # Validate thread ID format - either numeric or GitHub node ID
-    if not (thread_id.isdigit() or thread_id.startswith("PRT_")):
+    if not (thread_id.isdigit() or thread_id.startswith(("PRT_", "PRRT_"))):
         raise click.BadParameter(
             "Thread ID must be numeric (e.g., 123456789) or a "
-            "GitHub node ID starting with 'PRT_'",
+            "GitHub node ID starting with 'PRT_' or 'PRRT_'",
             param_hint="--thread-id",
         )
 
     # Additional validation for node IDs
-    if thread_id.startswith("PRT_") and len(thread_id) < 12:
+    if thread_id.startswith(("PRT_", "PRRT_")) and len(thread_id) < 12:
         raise click.BadParameter(
             "GitHub node ID appears too short to be valid",
             param_hint="--thread-id",

--- a/src/toady/resolve_mutations.py
+++ b/src/toady/resolve_mutations.py
@@ -22,7 +22,6 @@ class ResolveThreadMutationBuilder:
                 thread {
                     id
                     isResolved
-                    url
                 }
             }
         }
@@ -40,7 +39,6 @@ class ResolveThreadMutationBuilder:
                 thread {
                     id
                     isResolved
-                    url
                 }
             }
         }
@@ -64,10 +62,10 @@ class ResolveThreadMutationBuilder:
         thread_id = thread_id.strip()
 
         # Validate thread ID format
-        if not (thread_id.isdigit() or thread_id.startswith("PRT_")):
+        if not (thread_id.isdigit() or thread_id.startswith(("PRT_", "PRRT_"))):
             raise ValueError(
                 "Thread ID must be numeric (e.g., 123456789) or a "
-                "GitHub node ID starting with 'PRT_'"
+                "GitHub node ID starting with 'PRT_' or 'PRRT_'"
             )
 
         return {"threadId": thread_id}

--- a/tests/test_format_interfaces.py
+++ b/tests/test_format_interfaces.py
@@ -311,31 +311,22 @@ class TestFormatterError:
 class TestFormatterFactory:
     """Test the FormatterFactory class."""
 
-    def setUp(self):
-        """Set up test fixtures."""
-        # Clear the factory registry for clean tests
+    @pytest.fixture(autouse=True)
+    def clear_factory_registry(self):
+        """Clear factory registry before and after each test."""
         FormatterFactory._formatters.clear()
-
-    def tearDown(self):
-        """Clean up after tests."""
-        # Clear the factory registry
+        yield
         FormatterFactory._formatters.clear()
 
     def test_register_formatter(self):
         """Test registering a formatter."""
-        self.setUp()
-
         FormatterFactory.register("mock", MockFormatter)
 
         assert "mock" in FormatterFactory._formatters
         assert FormatterFactory._formatters["mock"] is MockFormatter
 
-        self.tearDown()
-
     def test_create_formatter(self):
         """Test creating a formatter instance."""
-        self.setUp()
-
         FormatterFactory.register("mock", MockFormatter)
 
         formatter = FormatterFactory.create("mock", test_option="value")
@@ -343,23 +334,16 @@ class TestFormatterFactory:
         assert isinstance(formatter, MockFormatter)
         assert formatter.options == {"test_option": "value"}
 
-        self.tearDown()
-
     def test_create_unknown_formatter(self):
         """Test creating an unknown formatter raises error."""
-        self.setUp()
-
         with pytest.raises(FormatterError) as excinfo:
             FormatterFactory.create("unknown")
 
         assert "Unknown formatter 'unknown'" in str(excinfo.value)
         assert "Available formatters:" in str(excinfo.value)
 
-        self.tearDown()
-
     def test_create_formatter_with_error(self):
         """Test creating a formatter that raises an error during construction."""
-        self.setUp()
 
         class FailingFormatter(MockFormatter):
             def __init__(self, **options):
@@ -380,12 +364,8 @@ class TestFormatterFactory:
         assert "Failed to create formatter 'failing'" in str(excinfo.value)
         assert isinstance(excinfo.value.original_error, ValueError)
 
-        self.tearDown()
-
     def test_list_formatters(self):
         """Test listing available formatters."""
-        self.setUp()
-
         assert FormatterFactory.list_formatters() == []
 
         FormatterFactory.register("mock1", MockFormatter)
@@ -394,20 +374,14 @@ class TestFormatterFactory:
         formatters = FormatterFactory.list_formatters()
         assert set(formatters) == {"mock1", "mock2"}
 
-        self.tearDown()
-
     def test_is_registered(self):
         """Test checking if a formatter is registered."""
-        self.setUp()
-
         assert FormatterFactory.is_registered("mock") is False
 
         FormatterFactory.register("mock", MockFormatter)
 
         assert FormatterFactory.is_registered("mock") is True
         assert FormatterFactory.is_registered("other") is False
-
-        self.tearDown()
 
 
 class TestFormatterIntegration:


### PR DESCRIPTION
- Updated the CLI to recognize and validate GitHub node IDs starting with 'PRRC_' in addition to 'IC_'.
- Modified help messages and documentation to reflect the new ID formats for comment and thread IDs.
- Enhanced the ResolveThreadMutationBuilder to accommodate the new thread ID format.
- Cleaned up test setup by using pytest fixtures for better test management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded support for additional GitHub node ID formats in CLI commands for replying to comments and resolving threads.
- **Documentation**
	- Added new task entries to the branch mapping documentation.
	- Updated help texts and usage examples to reflect new ID formats.
- **Refactor**
	- Improved test setup and teardown in formatting interface tests by using a pytest fixture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->