### PR TITLE
Enhance CLI resolve command with bulk resolution support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,11 @@ toady fetch --pr 123 --pretty
 ### Reply to a Review Comment
 
 ```bash
-toady reply --comment-id 12345678 --body "Thanks for the feedback! Fixed in latest commit."
+# Reply to a review thread (recommended for submitted reviews)
+toady reply --comment-id PRRT_kwDOO3WQIc5Rv3_r --body "Thanks for the feedback! Fixed in latest commit."
+
+# Reply using numeric ID (legacy)
+toady reply --comment-id 12345678 --body "Fixed!"
 ```
 
 ### Resolve/Unresolve Review Threads

--- a/src/toady/cli.py
+++ b/src/toady/cli.py
@@ -1,7 +1,7 @@
 """Main CLI interface for Toady."""
 
 import json
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, List, Tuple
 
 import click
 
@@ -403,7 +403,10 @@ def _build_json_reply(
     "--comment-id",
     required=True,
     type=str,
-    help="GitHub comment or thread ID (numeric, IC_/PRRC_/RP_, or PRT_/PRRT_/RT_)",
+    help=(
+        "GitHub thread ID (PRRT_/PRT_/RT_) or comment ID (numeric, IC_/RP_). "
+        "Note: PRRC_ IDs from submitted reviews won't work - use the thread ID instead"
+    ),
     metavar="ID",
 )
 @click.option(
@@ -432,8 +435,12 @@ def reply(
 
     Reply to comments or threads using:
     • Numeric IDs (e.g., 123456789) for legacy compatibility
-    • Comment node IDs (IC_, PRRC_, RP_) to reply to specific comments
     • Thread node IDs (PRT_, PRRT_, RT_) to reply to entire threads
+    • Comment node IDs (IC_, RP_) for individual comments (NOT in submitted reviews)
+
+    IMPORTANT: For submitted reviews, you MUST use thread IDs (PRRT_, PRT_, RT_).
+    Individual comment IDs (PRRC_) within submitted reviews cannot be replied to
+    directly - use the thread ID instead.
 
     Use --verbose/-v flag to show additional context including the PR title,
     parent comment author, and thread details.
@@ -442,11 +449,11 @@ def reply(
 
         toady reply --comment-id 123456789 --body "Fixed in latest commit"
 
+        toady reply --comment-id PRRT_kwDOO3WQIc5Rv3_r --body "Fixed!"
+
         toady reply --comment-id IC_kwDOABcD12MAAAABcDE3fg --body "Good catch!"
 
-        toady reply --comment-id PRRC_kwDOO3WQIc5_Pnh_ --body "Thanks for the review"
-
-        toady reply --comment-id RP_kwDOABcD12MAAAABcDE3fg --body "Updated" --pretty -v
+        toady reply --comment-id PRT_kwDOABcD12MAAAABcDE3fg --body "Updated" --pretty -v
     """
     # Validate arguments using helper function
     comment_id, body = _validate_reply_args(comment_id, body)
@@ -618,6 +625,7 @@ def reply(
 )
 @click.option(
     "--all",
+    "bulk_resolve",
     is_flag=True,
     help="Resolve all unresolved threads in the specified pull request",
 )
@@ -647,7 +655,7 @@ def reply(
 def resolve(
     ctx: click.Context,
     thread_id: str,
-    all: bool,
+    bulk_resolve: bool,
     pr_number: int,
     undo: bool,
     yes: bool,
@@ -676,12 +684,12 @@ def resolve(
         toady resolve --all --pr 123 --yes --pretty
     """
     # Validate mutually exclusive options
-    if all and thread_id:
+    if bulk_resolve and thread_id:
         raise click.BadParameter(
             "Cannot use --all and --thread-id together. Choose one."
         )
 
-    if not all and thread_id is None:
+    if not bulk_resolve and thread_id is None:
         raise click.BadParameter("Must specify either --thread-id or --all")
 
     # Validate PR number if provided
@@ -695,11 +703,11 @@ def resolve(
             )
 
     # Validate --pr requirement when using --all
-    if all and pr_number is None:
+    if bulk_resolve and pr_number is None:
         raise click.BadParameter("--pr is required when using --all", param_hint="--pr")
 
     # Handle bulk resolution mode
-    if all:
+    if bulk_resolve:
         try:
             _handle_bulk_resolve(ctx, pr_number, undo, yes, pretty)
         except SystemExit:
@@ -805,6 +813,196 @@ def resolve(
         ctx.exit(1)
 
 
+def _fetch_and_filter_threads(pr_number: int, undo: bool, pretty: bool) -> List[Any]:
+    """Fetch and filter threads based on resolution action.
+
+    Args:
+        pr_number: Pull request number
+        undo: Whether to fetch resolved threads (for unresolve) or unresolved (resolve)
+        pretty: Whether to show pretty progress messages
+
+    Returns:
+        List of filtered threads ready for processing
+    """
+    if pretty:
+        click.echo(f"🔍 Fetching threads from PR #{pr_number}...")
+
+    fetch_service = FetchService()
+    # For unresolve, we need to fetch resolved threads; for resolve, unresolved threads
+    include_resolved = undo
+    threads = fetch_service.fetch_review_threads_from_current_repo(
+        pr_number=pr_number,
+        include_resolved=include_resolved,
+        limit=100,  # Maximum allowed limit for bulk operations
+    )
+
+    # Filter threads based on action
+    if undo:
+        target_threads = [t for t in threads if t.is_resolved]
+    else:
+        target_threads = [t for t in threads if not t.is_resolved]
+
+    return target_threads
+
+
+def _handle_confirmation_prompt(
+    ctx: click.Context,
+    target_threads: List[Any],
+    action: str,
+    action_symbol: str,
+    pr_number: int,
+    yes: bool,
+    pretty: bool,
+) -> None:
+    """Handle user confirmation prompt for bulk operations.
+
+    Args:
+        ctx: Click context for exit handling
+        target_threads: List of threads to be processed
+        action: Action being performed (resolve/unresolve)
+        action_symbol: Emoji symbol for the action
+        pr_number: Pull request number
+        yes: Whether to skip confirmation
+        pretty: Whether to use pretty output
+    """
+    if yes:
+        return  # Skip confirmation if --yes flag is used
+
+    if pretty:
+        click.echo(
+            f"\n{action_symbol} About to {action} {len(target_threads)} "
+            f"thread(s) in PR #{pr_number}"
+        )
+        for i, thread in enumerate(target_threads[:5]):  # Show first 5
+            click.echo(f"   {i+1}. {thread.thread_id} - {thread.title}")
+        if len(target_threads) > 5:
+            click.echo(f"   ... and {len(target_threads) - 5} more")
+        click.echo()
+        if not click.confirm(f"Do you want to {action} these threads?"):
+            click.echo("❌ Operation cancelled")
+            ctx.exit(0)
+    else:
+        # For JSON mode, we still need confirmation unless --yes is used
+        click.echo(
+            f"About to {action} {len(target_threads)} thread(s). "
+            "Use --yes to skip this prompt.",
+            err=True,
+        )
+        ctx.exit(1)
+
+
+def _process_threads(
+    target_threads: List[Any],
+    undo: bool,
+    action_present: str,
+    action_symbol: str,
+    pretty: bool,
+) -> Tuple[int, int, List[Dict[str, str]]]:
+    """Process threads for resolution/unresolve with error handling.
+
+    Args:
+        target_threads: List of threads to process
+        undo: Whether to unresolve (True) or resolve (False)
+        action_present: Present tense action description
+        action_symbol: Emoji symbol for the action
+        pretty: Whether to show pretty progress messages
+
+    Returns:
+        Tuple of (succeeded_count, failed_count, failed_threads_list)
+    """
+    import time
+
+    if pretty:
+        click.echo(
+            f"\n{action_symbol} {action_present} {len(target_threads)} " "thread(s)..."
+        )
+
+    resolve_service = ResolveService()
+    succeeded = 0
+    failed = 0
+    failed_threads = []
+
+    for i, thread in enumerate(target_threads, 1):
+        if pretty:
+            click.echo(
+                f"   {action_symbol} {action_present} thread {i} of "
+                f"{len(target_threads)}: {thread.thread_id}"
+            )
+
+        try:
+            if undo:
+                resolve_service.unresolve_thread(thread.thread_id)
+            else:
+                resolve_service.resolve_thread(thread.thread_id)
+            succeeded += 1
+
+            # Add small delay to avoid rate limits
+            if i < len(target_threads):  # Don't sleep after the last request
+                time.sleep(0.1)
+
+        except GitHubRateLimitError as e:
+            failed += 1
+            failed_threads.append({"thread_id": thread.thread_id, "error": str(e)})
+            if pretty:
+                click.echo(f"     ❌ Failed: {e}", err=True)
+                click.echo(
+                    "     ⏳ Rate limit detected, waiting before continuing...",
+                    err=True,
+                )
+            time.sleep(min(2.0 ** min(failed, 5), 60))  # Exponential backoff, max 60s
+        except (ResolveServiceError, GitHubAPIError) as e:
+            failed += 1
+            failed_threads.append({"thread_id": thread.thread_id, "error": str(e)})
+            if pretty:
+                click.echo(f"     ❌ Failed: {e}", err=True)
+
+    return succeeded, failed, failed_threads
+
+
+def _display_summary(
+    target_threads: List[Any],
+    succeeded: int,
+    failed: int,
+    failed_threads: List[Dict[str, str]],
+    action: str,
+    action_past: str,
+    pr_number: int,
+    pretty: bool,
+) -> None:
+    """Display summary of bulk resolution results.
+
+    Args:
+        target_threads: List of threads that were processed
+        succeeded: Number of successful operations
+        failed: Number of failed operations
+        failed_threads: List of failed thread details
+        action: Action performed (resolve/unresolve)
+        action_past: Past tense action description
+        pr_number: Pull request number
+        pretty: Whether to use pretty output format
+    """
+    if pretty:
+        click.echo(f"\n✅ Bulk {action} completed:")
+        click.echo(f"   📊 Total threads processed: {len(target_threads)}")
+        click.echo(f"   ✅ Successfully {action_past}: {succeeded}")
+        if failed > 0:
+            click.echo(f"   ❌ Failed: {failed}")
+            click.echo("\n❌ Failed threads:")
+            for failure in failed_threads:
+                click.echo(f"   • {failure['thread_id']}: {failure['error']}")
+    else:
+        result = {
+            "pr_number": pr_number,
+            "action": action,
+            "threads_processed": len(target_threads),
+            "threads_succeeded": succeeded,
+            "threads_failed": failed,
+            "success": failed == 0,
+            "failed_threads": failed_threads,
+        }
+        click.echo(json.dumps(result))
+
+
 def _handle_bulk_resolve(
     ctx: click.Context, pr_number: int, undo: bool, yes: bool, pretty: bool
 ) -> None:
@@ -817,34 +1015,16 @@ def _handle_bulk_resolve(
         yes: Whether to skip confirmation prompt
         pretty: Whether to use pretty output format
     """
-    import time
-
     action = "unresolve" if undo else "resolve"
     action_past = "unresolved" if undo else "resolved"
     action_present = "Unresolving" if undo else "Resolving"
     action_symbol = "🔓" if undo else "🔒"
 
     try:
-        # First, fetch all unresolved threads
-        if pretty:
-            click.echo(f"🔍 Fetching threads from PR #{pr_number}...")
+        # Fetch and filter threads
+        target_threads = _fetch_and_filter_threads(pr_number, undo, pretty)
 
-        fetch_service = FetchService()
-        # For unresolve, we need to fetch resolved threads;
-        # for resolve, unresolved threads
-        include_resolved = undo
-        threads = fetch_service.fetch_review_threads_from_current_repo(
-            pr_number=pr_number,
-            include_resolved=include_resolved,
-            limit=100,  # Maximum allowed limit for bulk operations
-        )
-
-        # Filter threads based on action
-        if undo:
-            target_threads = [t for t in threads if t.is_resolved]
-        else:
-            target_threads = [t for t in threads if not t.is_resolved]
-
+        # Handle empty result
         if not target_threads:
             if pretty:
                 status = "resolved" if undo else "unresolved"
@@ -864,99 +1044,27 @@ def _handle_bulk_resolve(
                 click.echo(json.dumps(result))
             return
 
-        # Show confirmation prompt unless --yes is used
-        if not yes:
-            if pretty:
-                click.echo(
-                    f"\n{action_symbol} About to {action} {len(target_threads)} "
-                    f"thread(s) in PR #{pr_number}"
-                )
-                for i, thread in enumerate(target_threads[:5]):  # Show first 5
-                    click.echo(f"   {i+1}. {thread.thread_id} - {thread.title}")
-                if len(target_threads) > 5:
-                    click.echo(f"   ... and {len(target_threads) - 5} more")
-                click.echo()
-                if not click.confirm(f"Do you want to {action} these threads?"):
-                    click.echo("❌ Operation cancelled")
-                    ctx.exit(0)
-            else:
-                # For JSON mode, we still need confirmation unless --yes is used
-                click.echo(
-                    f"About to {action} {len(target_threads)} thread(s). "
-                    "Use --yes to skip this prompt.",
-                    err=True,
-                )
-                ctx.exit(1)
+        # Handle confirmation prompt
+        _handle_confirmation_prompt(
+            ctx, target_threads, action, action_symbol, pr_number, yes, pretty
+        )
 
-        # Process threads with progress indication
-        if pretty:
-            click.echo(
-                f"\n{action_symbol} {action_present} {len(target_threads)} "
-                "thread(s)..."
-            )
+        # Process threads
+        succeeded, failed, failed_threads = _process_threads(
+            target_threads, undo, action_present, action_symbol, pretty
+        )
 
-        resolve_service = ResolveService()
-        succeeded = 0
-        failed = 0
-        failed_threads = []
-
-        for i, thread in enumerate(target_threads, 1):
-            if pretty:
-                click.echo(
-                    f"   {action_symbol} {action_present} thread {i} of "
-                    f"{len(target_threads)}: {thread.thread_id}"
-                )
-
-            try:
-                if undo:
-                    resolve_service.unresolve_thread(thread.thread_id)
-                else:
-                    resolve_service.resolve_thread(thread.thread_id)
-                succeeded += 1
-
-                # Add small delay to avoid rate limits
-                if i < len(target_threads):  # Don't sleep after the last request
-                    time.sleep(0.1)
-
-            except GitHubRateLimitError as e:
-                failed += 1
-                failed_threads.append({"thread_id": thread.thread_id, "error": str(e)})
-                if pretty:
-                    click.echo(f"     ❌ Failed: {e}", err=True)
-                    click.echo(
-                        "     ⏳ Rate limit detected, waiting before continuing...",
-                        err=True,
-                    )
-                time.sleep(
-                    min(2.0 ** min(failed, 5), 60)
-                )  # Exponential backoff, max 60s
-            except (ResolveServiceError, GitHubAPIError) as e:
-                failed += 1
-                failed_threads.append({"thread_id": thread.thread_id, "error": str(e)})
-                if pretty:
-                    click.echo(f"     ❌ Failed: {e}", err=True)
-
-        # Show summary
-        if pretty:
-            click.echo(f"\n✅ Bulk {action} completed:")
-            click.echo(f"   📊 Total threads processed: {len(target_threads)}")
-            click.echo(f"   ✅ Successfully {action_past}: {succeeded}")
-            if failed > 0:
-                click.echo(f"   ❌ Failed: {failed}")
-                click.echo("\n❌ Failed threads:")
-                for failure in failed_threads:
-                    click.echo(f"   • {failure['thread_id']}: {failure['error']}")
-        else:
-            result = {
-                "pr_number": pr_number,
-                "action": action,
-                "threads_processed": len(target_threads),
-                "threads_succeeded": succeeded,
-                "threads_failed": failed,
-                "success": failed == 0,
-                "failed_threads": failed_threads,
-            }
-            click.echo(json.dumps(result))
+        # Display summary
+        _display_summary(
+            target_threads,
+            succeeded,
+            failed,
+            failed_threads,
+            action,
+            action_past,
+            pr_number,
+            pretty,
+        )
 
         # Exit with error code if any threads failed
         if failed > 0:

--- a/src/toady/cli.py
+++ b/src/toady/cli.py
@@ -612,10 +612,21 @@ def reply(
 @cli.command()
 @click.option(
     "--thread-id",
-    required=True,
     type=str,
     help="GitHub thread ID (numeric ID or node ID starting with PRT_/PRRT_/RT_)",
     metavar="ID",
+)
+@click.option(
+    "--all",
+    is_flag=True,
+    help="Resolve all unresolved threads in the specified pull request",
+)
+@click.option(
+    "--pr",
+    "pr_number",
+    type=int,
+    help="Pull request number (required when using --all)",
+    metavar="NUMBER",
 )
 @click.option(
     "--undo",
@@ -623,16 +634,32 @@ def reply(
     help="Unresolve the thread instead of resolving it",
 )
 @click.option(
+    "--yes",
+    is_flag=True,
+    help="Skip confirmation prompt for bulk operations",
+)
+@click.option(
     "--pretty",
     is_flag=True,
     help="Output in human-readable format instead of JSON",
 )
 @click.pass_context
-def resolve(ctx: click.Context, thread_id: str, undo: bool, pretty: bool) -> None:
+def resolve(
+    ctx: click.Context,
+    thread_id: str,
+    all: bool,
+    pr_number: int,
+    undo: bool,
+    yes: bool,
+    pretty: bool,
+) -> None:
     """Mark a review thread as resolved or unresolved.
 
     Resolve or unresolve review threads using either numeric IDs or
     GitHub node IDs for threads (PRT_), review threads (PRRT_), or legacy threads (RT_).
+
+    Use --all flag to resolve all unresolved threads in a pull request at once.
+    This requires --pr to specify the pull request number.
 
     Examples:
 
@@ -643,7 +670,44 @@ def resolve(ctx: click.Context, thread_id: str, undo: bool, pretty: bool) -> Non
         toady resolve --thread-id PRRT_kwDOO3WQIc5RvXMO
 
         toady resolve --thread-id RT_kwDOABcD12MAAAABcDE3fg --pretty
+
+        toady resolve --all --pr 123
+
+        toady resolve --all --pr 123 --yes --pretty
     """
+    # Validate mutually exclusive options
+    if all and thread_id:
+        raise click.BadParameter(
+            "Cannot use --all and --thread-id together. Choose one."
+        )
+
+    if not all and thread_id is None:
+        raise click.BadParameter("Must specify either --thread-id or --all")
+
+    # Validate PR number if provided
+    if pr_number is not None:
+        if pr_number <= 0:
+            raise click.BadParameter("PR number must be positive", param_hint="--pr")
+        if pr_number > MAX_PR_NUMBER:
+            raise click.BadParameter(
+                "PR number appears unreasonably large (maximum: 999,999)",
+                param_hint="--pr",
+            )
+
+    # Validate --pr requirement when using --all
+    if all and pr_number is None:
+        raise click.BadParameter("--pr is required when using --all", param_hint="--pr")
+
+    # Handle bulk resolution mode
+    if all:
+        try:
+            _handle_bulk_resolve(ctx, pr_number, undo, yes, pretty)
+        except SystemExit:
+            # Re-raise SystemExit to avoid being caught by outer exception handlers
+            raise
+        return
+
+    # Handle single thread resolution mode
     # Validate thread ID using centralized validation
     thread_id = thread_id.strip()
     if not thread_id:
@@ -735,6 +799,210 @@ def resolve(ctx: click.Context, thread_id: str, undo: bool, pretty: bool) -> Non
                 "action": "unresolve" if undo else "resolve",
                 "success": False,
                 "error": "api_error",
+                "error_message": str(e),
+            }
+            click.echo(json.dumps(error_result), err=True)
+        ctx.exit(1)
+
+
+def _handle_bulk_resolve(
+    ctx: click.Context, pr_number: int, undo: bool, yes: bool, pretty: bool
+) -> None:
+    """Handle bulk resolution of all threads in a pull request.
+
+    Args:
+        ctx: Click context for exit handling
+        pr_number: Pull request number
+        undo: Whether to unresolve instead of resolve
+        yes: Whether to skip confirmation prompt
+        pretty: Whether to use pretty output format
+    """
+    import time
+
+    action = "unresolve" if undo else "resolve"
+    action_past = "unresolved" if undo else "resolved"
+    action_present = "Unresolving" if undo else "Resolving"
+    action_symbol = "🔓" if undo else "🔒"
+
+    try:
+        # First, fetch all unresolved threads
+        if pretty:
+            click.echo(f"🔍 Fetching threads from PR #{pr_number}...")
+
+        fetch_service = FetchService()
+        # For unresolve, we need to fetch resolved threads;
+        # for resolve, unresolved threads
+        include_resolved = undo
+        threads = fetch_service.fetch_review_threads_from_current_repo(
+            pr_number=pr_number,
+            include_resolved=include_resolved,
+            limit=100,  # Maximum allowed limit for bulk operations
+        )
+
+        # Filter threads based on action
+        if undo:
+            target_threads = [t for t in threads if t.is_resolved]
+        else:
+            target_threads = [t for t in threads if not t.is_resolved]
+
+        if not target_threads:
+            if pretty:
+                status = "resolved" if undo else "unresolved"
+                click.echo(f"✅ No {status} threads found in PR #{pr_number}")
+            else:
+                result = {
+                    "pr_number": pr_number,
+                    "action": action,
+                    "threads_processed": 0,
+                    "threads_succeeded": 0,
+                    "threads_failed": 0,
+                    "success": True,
+                    "message": (
+                        f"No {'resolved' if undo else 'unresolved'} threads found"
+                    ),
+                }
+                click.echo(json.dumps(result))
+            return
+
+        # Show confirmation prompt unless --yes is used
+        if not yes:
+            if pretty:
+                click.echo(
+                    f"\n{action_symbol} About to {action} {len(target_threads)} "
+                    f"thread(s) in PR #{pr_number}"
+                )
+                for i, thread in enumerate(target_threads[:5]):  # Show first 5
+                    click.echo(f"   {i+1}. {thread.thread_id} - {thread.title}")
+                if len(target_threads) > 5:
+                    click.echo(f"   ... and {len(target_threads) - 5} more")
+                click.echo()
+                if not click.confirm(f"Do you want to {action} these threads?"):
+                    click.echo("❌ Operation cancelled")
+                    ctx.exit(0)
+            else:
+                # For JSON mode, we still need confirmation unless --yes is used
+                click.echo(
+                    f"About to {action} {len(target_threads)} thread(s). "
+                    "Use --yes to skip this prompt.",
+                    err=True,
+                )
+                ctx.exit(1)
+
+        # Process threads with progress indication
+        if pretty:
+            click.echo(
+                f"\n{action_symbol} {action_present} {len(target_threads)} "
+                "thread(s)..."
+            )
+
+        resolve_service = ResolveService()
+        succeeded = 0
+        failed = 0
+        failed_threads = []
+
+        for i, thread in enumerate(target_threads, 1):
+            if pretty:
+                click.echo(
+                    f"   {action_symbol} {action_present} thread {i} of "
+                    f"{len(target_threads)}: {thread.thread_id}"
+                )
+
+            try:
+                if undo:
+                    resolve_service.unresolve_thread(thread.thread_id)
+                else:
+                    resolve_service.resolve_thread(thread.thread_id)
+                succeeded += 1
+
+                # Add small delay to avoid rate limits
+                if i < len(target_threads):  # Don't sleep after the last request
+                    time.sleep(0.1)
+
+            except GitHubRateLimitError as e:
+                failed += 1
+                failed_threads.append({"thread_id": thread.thread_id, "error": str(e)})
+                if pretty:
+                    click.echo(f"     ❌ Failed: {e}", err=True)
+                    click.echo(
+                        "     ⏳ Rate limit detected, waiting before continuing...",
+                        err=True,
+                    )
+                time.sleep(
+                    min(2.0 ** min(failed, 5), 60)
+                )  # Exponential backoff, max 60s
+            except (ResolveServiceError, GitHubAPIError) as e:
+                failed += 1
+                failed_threads.append({"thread_id": thread.thread_id, "error": str(e)})
+                if pretty:
+                    click.echo(f"     ❌ Failed: {e}", err=True)
+
+        # Show summary
+        if pretty:
+            click.echo(f"\n✅ Bulk {action} completed:")
+            click.echo(f"   📊 Total threads processed: {len(target_threads)}")
+            click.echo(f"   ✅ Successfully {action_past}: {succeeded}")
+            if failed > 0:
+                click.echo(f"   ❌ Failed: {failed}")
+                click.echo("\n❌ Failed threads:")
+                for failure in failed_threads:
+                    click.echo(f"   • {failure['thread_id']}: {failure['error']}")
+        else:
+            result = {
+                "pr_number": pr_number,
+                "action": action,
+                "threads_processed": len(target_threads),
+                "threads_succeeded": succeeded,
+                "threads_failed": failed,
+                "success": failed == 0,
+                "failed_threads": failed_threads,
+            }
+            click.echo(json.dumps(result))
+
+        # Exit with error code if any threads failed
+        if failed > 0:
+            ctx.exit(1)
+
+    except FetchServiceError as e:
+        if pretty:
+            click.echo(f"❌ Failed to fetch threads: {e}", err=True)
+        else:
+            error_result = {
+                "pr_number": pr_number,
+                "action": action,
+                "success": False,
+                "error": "fetch_failed",
+                "error_message": str(e),
+            }
+            click.echo(json.dumps(error_result), err=True)
+        ctx.exit(1)
+
+    except GitHubAuthenticationError as e:
+        if pretty:
+            click.echo(f"❌ Authentication failed: {e}", err=True)
+            click.echo("💡 Try running: gh auth login", err=True)
+        else:
+            error_result = {
+                "pr_number": pr_number,
+                "action": action,
+                "success": False,
+                "error": "authentication_failed",
+                "error_message": str(e),
+            }
+            click.echo(json.dumps(error_result), err=True)
+        ctx.exit(1)
+
+    except click.exceptions.Exit:
+        # Re-raise Exit exceptions (e.g., from ctx.exit(0) when user cancels)
+        raise
+    except Exception as e:
+        if pretty:
+            click.echo(f"❌ Unexpected error during bulk {action}: {e}", err=True)
+        else:
+            error_result = {
+                "pr_number": pr_number,
+                "action": action,
+                "success": False,
+                "error": "internal_error",
                 "error_message": str(e),
             }
             click.echo(json.dumps(error_result), err=True)


### PR DESCRIPTION
- Added `--all` flag to resolve all unresolved threads in a specified pull request, requiring the `--pr` option.
- Implemented validation to ensure `--all` and `--thread-id` options are mutually exclusive.
- Introduced `_handle_bulk_resolve` function to manage bulk resolution logic, including confirmation prompts and error handling.
- Updated tests to cover new functionality, ensuring proper validation and handling of edge cases for bulk operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the CLI with a new bulk operation option to resolve or unresolve all review threads in a pull request using the `--all` flag.
  - Added the `--yes` flag to allow skipping confirmation prompts during bulk operations.
  - Improved command validation and user feedback for bulk actions.
  - Updated reply command examples to clarify valid GitHub comment and thread ID formats.

- **Bug Fixes**
  - Improved error handling and validation for pull request numbers and command-line options.

- **Tests**
  - Expanded test coverage to include all new bulk operation scenarios, validation, error handling, and help text updates.

- **Documentation**
  - Updated README to clarify recommended usage of reply command with review thread IDs and legacy comment IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->