### PR TITLE
Tony/bur-88-task-183-design-interactive-pr-selection-interface

### DIFF
--- a/src/toady/fetch_service.py
+++ b/src/toady/fetch_service.py
@@ -326,7 +326,8 @@ class FetchService:
                     return [], None
 
                 # At this point, should_continue is True, so pr_number must be set
-                assert selection_result.pr_number is not None
+                if selection_result.pr_number is None:
+                    raise FetchServiceError("Unexpected empty selection result")
                 selected_pr_number = selection_result.pr_number
 
             # Fetch review threads from the selected PR

--- a/src/toady/pr_selector.py
+++ b/src/toady/pr_selector.py
@@ -1,0 +1,238 @@
+"""Interactive pull request selection interface."""
+
+from typing import List, Optional
+
+import click
+
+from .formatters import PrettyFormatter
+from .models import PullRequest
+
+
+class PRSelector:
+    """Interactive pull request selection interface.
+
+    Provides user-friendly interface for selecting from multiple PRs
+    with formatted display and navigation controls.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the PR selector."""
+        self.formatter = PrettyFormatter()
+
+    def select_pr(self, pull_requests: List[PullRequest]) -> Optional[int]:
+        """Select a PR from the given list through interactive interface.
+
+        Args:
+            pull_requests: List of available pull requests
+
+        Returns:
+            Selected PR number, or None if user cancels
+
+        Raises:
+            ValidationError: If input validation fails
+        """
+        if not pull_requests:
+            return None
+
+        if len(pull_requests) == 1:
+            # Auto-select single PR
+            return pull_requests[0].number
+
+        # Multiple PRs - show interactive selection
+        return self._show_pr_selection_menu(pull_requests)
+
+    def _show_pr_selection_menu(
+        self, pull_requests: List[PullRequest]
+    ) -> Optional[int]:
+        """Display interactive PR selection menu.
+
+        Args:
+            pull_requests: List of pull requests to choose from
+
+        Returns:
+            Selected PR number, or None if cancelled
+        """
+        # Display header
+        click.echo()
+        plural = "s" if len(pull_requests) != 1 else ""
+        header = f"📋 Found {len(pull_requests)} open pull request{plural}"
+        click.echo(click.style(header, bold=True, fg="cyan"))
+        click.echo()
+
+        # Display PR list with formatting
+        self._display_pr_list(pull_requests)
+
+        # Get user selection
+        return self._prompt_for_selection(pull_requests)
+
+    def _display_pr_list(self, pull_requests: List[PullRequest]) -> None:
+        """Display formatted list of pull requests.
+
+        Args:
+            pull_requests: List of pull requests to display
+        """
+        for i, pr in enumerate(pull_requests, 1):
+            # Format PR entry with consistent styling
+            number_style = click.style(f"[{i}]", bold=True, fg="yellow")
+            pr_number = click.style(f"#{pr.number}", bold=True, fg="green")
+            title = click.style(pr.title, fg="white")
+
+            # Format author and branch info
+            author_info = click.style(f"by {pr.author}", fg="blue")
+            branch_info = click.style(f"{pr.head_ref} → {pr.base_ref}", fg="magenta")
+
+            # Add draft indicator if applicable
+            draft_indicator = ""
+            if pr.is_draft:
+                draft_indicator = click.style(" [DRAFT]", fg="yellow", dim=True)
+
+            # Add review thread count if any
+            thread_info = ""
+            if pr.review_thread_count > 0:
+                plural = "s" if pr.review_thread_count != 1 else ""
+                thread_count = click.style(
+                    f" ({pr.review_thread_count} thread{plural})",
+                    fg="red",
+                    dim=True,
+                )
+                thread_info = thread_count
+
+            # Combine all components
+            click.echo(f"  {number_style} {pr_number} {title}{draft_indicator}")
+            click.echo(f"      {author_info} • {branch_info}{thread_info}")
+            click.echo()
+
+    def _prompt_for_selection(self, pull_requests: List[PullRequest]) -> Optional[int]:
+        """Prompt user for PR selection with validation.
+
+        Args:
+            pull_requests: List of available pull requests
+
+        Returns:
+            Selected PR number, or None if cancelled
+        """
+        while True:
+            try:
+                # Create choice prompt
+                max_num = len(pull_requests)
+                prompt_text = click.style(
+                    f"Select a pull request [1-{max_num}] (or 'q' to quit): ",
+                    fg="cyan",
+                )
+
+                choice = click.prompt(prompt_text, type=str, show_default=False)
+
+                # Handle quit
+                if choice.lower() in ("q", "quit", "exit"):
+                    click.echo(click.style("Operation cancelled.", fg="yellow"))
+                    return None
+
+                # Validate numeric input
+                try:
+                    selection = int(choice)
+                except ValueError:
+                    max_num = len(pull_requests)
+                    error_msg = (
+                        f"Error: Please enter a number between 1 and {max_num}, "
+                        "or 'q' to quit."
+                    )
+                    click.echo(
+                        click.style(
+                            error_msg,
+                            fg="red",
+                        )
+                    )
+                    continue
+
+                # Validate range
+                if not 1 <= selection <= len(pull_requests):
+                    max_num = len(pull_requests)
+                    error_msg = f"Error: Please enter a number between 1 and {max_num}."
+                    click.echo(
+                        click.style(
+                            error_msg,
+                            fg="red",
+                        )
+                    )
+                    continue
+
+                # Get selected PR
+                selected_pr = pull_requests[selection - 1]
+
+                # Show confirmation
+                confirm_text = click.style(
+                    f"Selected PR #{selected_pr.number}: {selected_pr.title}",
+                    fg="green",
+                    bold=True,
+                )
+                click.echo(f"✅ {confirm_text}")
+                click.echo()
+
+                return selected_pr.number
+
+            except (KeyboardInterrupt, click.Abort):
+                click.echo()
+                click.echo(click.style("Operation cancelled.", fg="yellow"))
+                return None
+
+    def display_no_prs_message(self) -> None:
+        """Display message when no open PRs are found."""
+        click.echo()
+        message = "📝 No open pull requests found in this repository."
+        click.echo(click.style(message, fg="yellow", bold=True))
+
+        suggestion = (
+            "To fetch review threads, please specify a PR number using --pr option."
+        )
+        click.echo(click.style(suggestion, fg="cyan"))
+        click.echo()
+
+    def display_auto_selected_pr(self, pr: PullRequest) -> None:
+        """Display message when automatically selecting single PR.
+
+        Args:
+            pr: The automatically selected pull request
+        """
+        click.echo()
+        header = "🎯 Auto-selected the only open pull request:"
+        click.echo(click.style(header, fg="green", bold=True))
+
+        pr_info = f"#{pr.number}: {pr.title}"
+        click.echo(click.style(pr_info, fg="white", bold=True))
+
+        author_branch = f"by {pr.author} • {pr.head_ref} → {pr.base_ref}"
+        click.echo(click.style(author_branch, fg="blue"))
+        click.echo()
+
+
+class PRSelectionResult:
+    """Result of PR selection process."""
+
+    def __init__(self, pr_number: Optional[int], cancelled: bool = False) -> None:
+        """Initialize selection result.
+
+        Args:
+            pr_number: Selected PR number, None if no selection
+            cancelled: True if user cancelled the operation
+        """
+        self.pr_number = pr_number
+        self.cancelled = cancelled
+
+    @property
+    def has_selection(self) -> bool:
+        """Check if a PR was selected."""
+        return self.pr_number is not None
+
+    @property
+    def should_continue(self) -> bool:
+        """Check if operation should continue."""
+        return self.has_selection and not self.cancelled
+
+
+def create_pr_selector() -> PRSelector:
+    """Factory function to create PR selector instance.
+
+    Returns:
+        Configured PRSelector instance
+    """
+    return PRSelector()

--- a/tests/unit/test_fetch_service_pr_selection.py
+++ b/tests/unit/test_fetch_service_pr_selection.py
@@ -1,0 +1,483 @@
+"""Tests for FetchService PR selection functionality."""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from toady.fetch_service import FetchService, FetchServiceError
+from toady.github_service import GitHubAPIError, GitHubAuthenticationError
+from toady.models import PullRequest, ReviewThread
+from toady.pr_selector import PRSelectionResult
+
+
+class TestFetchServicePRSelection:
+    """Test FetchService interactive PR selection functionality."""
+
+    def setup_method(self) -> None:
+        """Set up test fixtures."""
+        self.mock_github_service = MagicMock()
+        self.fetch_service = FetchService(github_service=self.mock_github_service)
+
+    def test_select_pr_interactively_no_prs(self) -> None:
+        """Test interactive PR selection when no PRs are found."""
+        # Mock fetch_open_pull_requests_from_current_repo to return empty list
+        self.fetch_service.fetch_open_pull_requests_from_current_repo = MagicMock(
+            return_value=[]
+        )
+
+        # Mock display_no_prs_message
+        self.fetch_service.pr_selector.display_no_prs_message = MagicMock()
+
+        result = self.fetch_service.select_pr_interactively()
+
+        assert isinstance(result, PRSelectionResult)
+        assert result.pr_number is None
+        assert result.cancelled is False
+        assert not result.has_selection
+        assert not result.should_continue
+
+        # Verify methods were called
+        self.fetch_service.fetch_open_pull_requests_from_current_repo.assert_called_once_with(
+            include_drafts=False, limit=100
+        )
+        self.fetch_service.pr_selector.display_no_prs_message.assert_called_once()
+
+    def test_select_pr_interactively_single_pr(self) -> None:
+        """Test interactive PR selection with single PR auto-selection."""
+        pr = PullRequest(
+            number=42,
+            title="Test PR",
+            author="testuser",
+            head_ref="feature",
+            base_ref="main",
+            is_draft=False,
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            url="https://github.com/test/repo/pull/42",
+            review_thread_count=0,
+        )
+
+        # Mock fetch_open_pull_requests_from_current_repo to return single PR
+        self.fetch_service.fetch_open_pull_requests_from_current_repo = MagicMock(
+            return_value=[pr]
+        )
+
+        # Mock display_auto_selected_pr
+        self.fetch_service.pr_selector.display_auto_selected_pr = MagicMock()
+
+        result = self.fetch_service.select_pr_interactively()
+
+        assert isinstance(result, PRSelectionResult)
+        assert result.pr_number == 42
+        assert result.cancelled is False
+        assert result.has_selection
+        assert result.should_continue
+
+        # Verify methods were called
+        self.fetch_service.pr_selector.display_auto_selected_pr.assert_called_once_with(
+            pr
+        )
+
+    def test_select_pr_interactively_multiple_prs_selection(self) -> None:
+        """Test interactive PR selection with multiple PRs and user selection."""
+        prs = [
+            PullRequest(
+                number=41,
+                title="First PR",
+                author="user1",
+                head_ref="feature1",
+                base_ref="main",
+                is_draft=False,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                url="https://github.com/test/repo/pull/41",
+                review_thread_count=1,
+            ),
+            PullRequest(
+                number=42,
+                title="Second PR",
+                author="user2",
+                head_ref="feature2",
+                base_ref="main",
+                is_draft=False,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                url="https://github.com/test/repo/pull/42",
+                review_thread_count=0,
+            ),
+        ]
+
+        # Mock fetch_open_pull_requests_from_current_repo to return multiple PRs
+        self.fetch_service.fetch_open_pull_requests_from_current_repo = MagicMock(
+            return_value=prs
+        )
+
+        # Mock select_pr to return selection
+        self.fetch_service.pr_selector.select_pr = MagicMock(return_value=42)
+
+        result = self.fetch_service.select_pr_interactively()
+
+        assert isinstance(result, PRSelectionResult)
+        assert result.pr_number == 42
+        assert result.cancelled is False
+        assert result.has_selection
+        assert result.should_continue
+
+        # Verify methods were called
+        self.fetch_service.pr_selector.select_pr.assert_called_once_with(prs)
+
+    def test_select_pr_interactively_multiple_prs_cancelled(self) -> None:
+        """Test interactive PR selection with user cancellation."""
+        prs = [
+            PullRequest(
+                number=41,
+                title="First PR",
+                author="user1",
+                head_ref="feature1",
+                base_ref="main",
+                is_draft=False,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                url="https://github.com/test/repo/pull/41",
+                review_thread_count=1,
+            ),
+            PullRequest(
+                number=42,
+                title="Second PR",
+                author="user2",
+                head_ref="feature2",
+                base_ref="main",
+                is_draft=False,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                url="https://github.com/test/repo/pull/42",
+                review_thread_count=0,
+            ),
+        ]
+
+        # Mock fetch_open_pull_requests_from_current_repo to return PRs
+        self.fetch_service.fetch_open_pull_requests_from_current_repo = MagicMock(
+            return_value=prs
+        )
+
+        # Mock select_pr to return None (cancelled)
+        self.fetch_service.pr_selector.select_pr = MagicMock(return_value=None)
+
+        result = self.fetch_service.select_pr_interactively()
+
+        assert isinstance(result, PRSelectionResult)
+        assert result.pr_number is None
+        assert result.cancelled is True
+        assert not result.has_selection
+        assert not result.should_continue
+
+    def test_select_pr_interactively_with_drafts(self) -> None:
+        """Test interactive PR selection with include_drafts option."""
+        # Mock fetch_open_pull_requests_from_current_repo
+        self.fetch_service.fetch_open_pull_requests_from_current_repo = MagicMock(
+            return_value=[]
+        )
+        self.fetch_service.pr_selector.display_no_prs_message = MagicMock()
+
+        self.fetch_service.select_pr_interactively(include_drafts=True, limit=50)
+
+        # Verify correct parameters were passed
+        self.fetch_service.fetch_open_pull_requests_from_current_repo.assert_called_once_with(
+            include_drafts=True, limit=50
+        )
+
+    def test_select_pr_interactively_github_error(self) -> None:
+        """Test interactive PR selection with GitHub API error."""
+        # Mock fetch_open_pull_requests_from_current_repo to raise GitHubAPIError
+        self.fetch_service.fetch_open_pull_requests_from_current_repo = MagicMock(
+            side_effect=GitHubAPIError("API error")
+        )
+
+        # Should re-raise GitHub service errors
+        with pytest.raises(GitHubAPIError, match="API error"):
+            self.fetch_service.select_pr_interactively()
+
+    def test_select_pr_interactively_other_error(self) -> None:
+        """Test interactive PR selection with other errors."""
+        # Mock fetch_open_pull_requests_from_current_repo to raise generic error
+        self.fetch_service.fetch_open_pull_requests_from_current_repo = MagicMock(
+            side_effect=ValueError("Some error")
+        )
+
+        # Should wrap in FetchServiceError
+        with pytest.raises(
+            FetchServiceError, match="Failed to select PR interactively"
+        ):
+            self.fetch_service.select_pr_interactively()
+
+    def test_fetch_review_threads_with_pr_selection_provided_pr(self) -> None:
+        """Test fetching threads with provided PR number (no selection needed)."""
+        threads = [
+            ReviewThread(
+                thread_id="RT_123",
+                title="Test thread",
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                status="UNRESOLVED",
+                author="reviewer",
+                comments=[],
+            )
+        ]
+
+        # Mock fetch_review_threads_from_current_repo
+        self.fetch_service.fetch_review_threads_from_current_repo = MagicMock(
+            return_value=threads
+        )
+
+        result_threads, selected_pr = (
+            self.fetch_service.fetch_review_threads_with_pr_selection(
+                pr_number=42,
+                include_resolved=True,
+                threads_limit=50,
+            )
+        )
+
+        assert result_threads == threads
+        assert selected_pr == 42
+
+        # Verify fetch was called with correct parameters
+        self.fetch_service.fetch_review_threads_from_current_repo.assert_called_once_with(
+            pr_number=42, include_resolved=True, limit=50
+        )
+
+    def test_fetch_review_threads_with_pr_selection_interactive_success(self) -> None:
+        """Test fetching threads with successful interactive PR selection."""
+        threads = [
+            ReviewThread(
+                thread_id="RT_123",
+                title="Test thread",
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                status="UNRESOLVED",
+                author="reviewer",
+                comments=[],
+            )
+        ]
+
+        # Mock select_pr_interactively to return successful selection
+        self.fetch_service.select_pr_interactively = MagicMock(
+            return_value=PRSelectionResult(pr_number=42, cancelled=False)
+        )
+
+        # Mock fetch_review_threads_from_current_repo
+        self.fetch_service.fetch_review_threads_from_current_repo = MagicMock(
+            return_value=threads
+        )
+
+        result_threads, selected_pr = (
+            self.fetch_service.fetch_review_threads_with_pr_selection(
+                pr_number=None,
+                include_resolved=True,
+                include_drafts=True,
+                threads_limit=50,
+                prs_limit=25,
+            )
+        )
+
+        assert result_threads == threads
+        assert selected_pr == 42
+
+        # Verify interactive selection was called
+        self.fetch_service.select_pr_interactively.assert_called_once_with(
+            include_drafts=True, limit=25
+        )
+
+        # Verify fetch was called with selected PR
+        self.fetch_service.fetch_review_threads_from_current_repo.assert_called_once_with(
+            pr_number=42, include_resolved=True, limit=50
+        )
+
+    def test_fetch_review_threads_with_pr_selection_interactive_cancelled(self) -> None:
+        """Test fetching threads with cancelled interactive PR selection."""
+        # Mock select_pr_interactively to return cancelled selection
+        self.fetch_service.select_pr_interactively = MagicMock(
+            return_value=PRSelectionResult(pr_number=None, cancelled=True)
+        )
+
+        result_threads, selected_pr = (
+            self.fetch_service.fetch_review_threads_with_pr_selection(pr_number=None)
+        )
+
+        assert result_threads == []
+        assert selected_pr is None
+
+        # Should not call fetch_review_threads_from_current_repo
+        self.fetch_service.fetch_review_threads_from_current_repo = MagicMock()
+        assert not self.fetch_service.fetch_review_threads_from_current_repo.called
+
+    def test_fetch_review_threads_with_pr_selection_interactive_no_prs(self) -> None:
+        """Test fetching threads when no PRs are available."""
+        # Mock select_pr_interactively to return no selection (no PRs)
+        self.fetch_service.select_pr_interactively = MagicMock(
+            return_value=PRSelectionResult(pr_number=None, cancelled=False)
+        )
+
+        result_threads, selected_pr = (
+            self.fetch_service.fetch_review_threads_with_pr_selection(pr_number=None)
+        )
+
+        assert result_threads == []
+        assert selected_pr is None
+
+    def test_fetch_review_threads_with_pr_selection_github_error(self) -> None:
+        """Test error handling in fetch_review_threads_with_pr_selection."""
+        # Mock select_pr_interactively to raise GitHubAuthenticationError
+        self.fetch_service.select_pr_interactively = MagicMock(
+            side_effect=GitHubAuthenticationError("Auth failed")
+        )
+
+        # Should re-raise GitHub service errors
+        with pytest.raises(GitHubAuthenticationError, match="Auth failed"):
+            self.fetch_service.fetch_review_threads_with_pr_selection(pr_number=None)
+
+    def test_fetch_review_threads_with_pr_selection_other_error(self) -> None:
+        """Test error wrapping in fetch_review_threads_with_pr_selection."""
+        # Mock select_pr_interactively to raise generic error
+        self.fetch_service.select_pr_interactively = MagicMock(
+            side_effect=RuntimeError("Unexpected error")
+        )
+
+        # Should wrap in FetchServiceError
+        with pytest.raises(
+            FetchServiceError, match="Failed to fetch review threads with PR selection"
+        ):
+            self.fetch_service.fetch_review_threads_with_pr_selection(pr_number=None)
+
+
+class TestFetchServicePRSelectionIntegration:
+    """Integration tests for FetchService PR selection functionality."""
+
+    def setup_method(self) -> None:
+        """Set up test fixtures."""
+        self.mock_github_service = MagicMock()
+        self.fetch_service = FetchService(github_service=self.mock_github_service)
+
+    def test_end_to_end_single_pr_workflow(self) -> None:
+        """Test complete workflow with single PR auto-selection."""
+        pr = PullRequest(
+            number=42,
+            title="Test PR",
+            author="testuser",
+            head_ref="feature",
+            base_ref="main",
+            is_draft=False,
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            url="https://github.com/test/repo/pull/42",
+            review_thread_count=1,
+        )
+
+        threads = [
+            ReviewThread(
+                thread_id="RT_123",
+                title="Test thread",
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                status="UNRESOLVED",
+                author="reviewer",
+                comments=[],
+            )
+        ]
+
+        # Mock the complete workflow
+        self.fetch_service.fetch_open_pull_requests_from_current_repo = MagicMock(
+            return_value=[pr]
+        )
+        self.fetch_service.fetch_review_threads_from_current_repo = MagicMock(
+            return_value=threads
+        )
+        self.fetch_service.pr_selector.display_auto_selected_pr = MagicMock()
+
+        # Test the complete workflow
+        result_threads, selected_pr = (
+            self.fetch_service.fetch_review_threads_with_pr_selection()
+        )
+
+        assert result_threads == threads
+        assert selected_pr == 42
+
+        # Verify all steps were executed
+        self.fetch_service.fetch_open_pull_requests_from_current_repo.assert_called_once()
+        self.fetch_service.pr_selector.display_auto_selected_pr.assert_called_once_with(
+            pr
+        )
+        self.fetch_service.fetch_review_threads_from_current_repo.assert_called_once_with(
+            pr_number=42, include_resolved=False, limit=100
+        )
+
+    @patch("toady.pr_selector.click.prompt")
+    @patch("toady.pr_selector.click.echo")
+    def test_end_to_end_multiple_prs_workflow(self, mock_echo, mock_prompt) -> None:
+        """Test complete workflow with multiple PRs and user selection."""
+        mock_prompt.return_value = "1"
+
+        prs = [
+            PullRequest(
+                number=41,
+                title="First PR",
+                author="user1",
+                head_ref="feature1",
+                base_ref="main",
+                is_draft=False,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                url="https://github.com/test/repo/pull/41",
+                review_thread_count=2,
+            ),
+            PullRequest(
+                number=42,
+                title="Second PR",
+                author="user2",
+                head_ref="feature2",
+                base_ref="main",
+                is_draft=False,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                url="https://github.com/test/repo/pull/42",
+                review_thread_count=1,
+            ),
+        ]
+
+        threads = [
+            ReviewThread(
+                thread_id="RT_123",
+                title="Test thread",
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                status="UNRESOLVED",
+                author="reviewer",
+                comments=[],
+            )
+        ]
+
+        # Mock the complete workflow
+        self.fetch_service.fetch_open_pull_requests_from_current_repo = MagicMock(
+            return_value=prs
+        )
+        self.fetch_service.fetch_review_threads_from_current_repo = MagicMock(
+            return_value=threads
+        )
+
+        # Test the complete workflow
+        result_threads, selected_pr = (
+            self.fetch_service.fetch_review_threads_with_pr_selection()
+        )
+
+        assert result_threads == threads
+        assert selected_pr == 41  # User selected first PR
+
+        # Verify all steps were executed
+        self.fetch_service.fetch_open_pull_requests_from_current_repo.assert_called_once()
+        self.fetch_service.fetch_review_threads_from_current_repo.assert_called_once_with(
+            pr_number=41, include_resolved=False, limit=100
+        )
+
+        # Verify user interaction occurred
+        mock_prompt.assert_called_once()
+        assert mock_echo.call_count > 0

--- a/tests/unit/test_pr_selector.py
+++ b/tests/unit/test_pr_selector.py
@@ -1,0 +1,463 @@
+"""Tests for the PR selector module."""
+
+from datetime import datetime
+from unittest.mock import patch
+
+from toady.models import PullRequest
+from toady.pr_selector import PRSelectionResult, PRSelector, create_pr_selector
+
+
+class TestPRSelector:
+    """Test the PRSelector class."""
+
+    def test_init(self) -> None:
+        """Test PRSelector initialization."""
+        selector = PRSelector()
+        assert selector is not None
+        assert selector.formatter is not None
+
+    def test_select_pr_empty_list(self) -> None:
+        """Test selecting from empty PR list returns None."""
+        selector = PRSelector()
+        result = selector.select_pr([])
+        assert result is None
+
+    def test_select_pr_single_pr(self) -> None:
+        """Test selecting from single PR auto-selects it."""
+        selector = PRSelector()
+        pr = PullRequest(
+            number=42,
+            title="Test PR",
+            author="testuser",
+            head_ref="feature",
+            base_ref="main",
+            is_draft=False,
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            url="https://github.com/test/repo/pull/42",
+            review_thread_count=0,
+        )
+
+        result = selector.select_pr([pr])
+        assert result == 42
+
+    @patch("click.echo")
+    @patch("click.prompt")
+    def test_select_pr_multiple_prs_valid_selection(
+        self, mock_prompt, mock_echo
+    ) -> None:
+        """Test selecting from multiple PRs with valid user input."""
+        mock_prompt.return_value = "2"
+
+        selector = PRSelector()
+        prs = [
+            PullRequest(
+                number=41,
+                title="First PR",
+                author="user1",
+                head_ref="feature1",
+                base_ref="main",
+                is_draft=False,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                url="https://github.com/test/repo/pull/41",
+                review_thread_count=1,
+            ),
+            PullRequest(
+                number=42,
+                title="Second PR",
+                author="user2",
+                head_ref="feature2",
+                base_ref="main",
+                is_draft=True,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                url="https://github.com/test/repo/pull/42",
+                review_thread_count=0,
+            ),
+        ]
+
+        result = selector.select_pr(prs)
+        assert result == 42
+
+        # Verify user interaction
+        mock_prompt.assert_called_once()
+        # Should show header, PR list, and confirmation
+        assert mock_echo.call_count >= 5
+
+    @patch("click.echo")
+    @patch("click.prompt")
+    def test_select_pr_multiple_prs_quit(self, mock_prompt, mock_echo) -> None:
+        """Test quitting from PR selection."""
+        mock_prompt.return_value = "q"
+
+        selector = PRSelector()
+        prs = [
+            PullRequest(
+                number=41,
+                title="First PR",
+                author="user1",
+                head_ref="feature1",
+                base_ref="main",
+                is_draft=False,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                url="https://github.com/test/repo/pull/41",
+                review_thread_count=1,
+            ),
+            PullRequest(
+                number=42,
+                title="Second PR",
+                author="user2",
+                head_ref="feature2",
+                base_ref="main",
+                is_draft=False,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                url="https://github.com/test/repo/pull/42",
+                review_thread_count=0,
+            ),
+        ]
+
+        result = selector.select_pr(prs)
+        assert result is None
+
+    @patch("click.echo")
+    @patch("click.prompt")
+    def test_select_pr_invalid_then_valid_selection(
+        self, mock_prompt, mock_echo
+    ) -> None:
+        """Test invalid input followed by valid selection."""
+        mock_prompt.side_effect = ["invalid", "0", "3", "1"]
+
+        selector = PRSelector()
+        prs = [
+            PullRequest(
+                number=41,
+                title="First PR",
+                author="user1",
+                head_ref="feature1",
+                base_ref="main",
+                is_draft=False,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                url="https://github.com/test/repo/pull/41",
+                review_thread_count=1,
+            ),
+            PullRequest(
+                number=42,
+                title="Second PR",
+                author="user2",
+                head_ref="feature2",
+                base_ref="main",
+                is_draft=False,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                url="https://github.com/test/repo/pull/42",
+                review_thread_count=0,
+            ),
+        ]
+
+        result = selector.select_pr(prs)
+        assert result == 41
+
+        # Should have been called 4 times due to invalid inputs
+        assert mock_prompt.call_count == 4
+
+    @patch("click.echo")
+    @patch("click.prompt")
+    def test_select_pr_keyboard_interrupt(self, mock_prompt, mock_echo) -> None:
+        """Test handling keyboard interrupt during selection."""
+        mock_prompt.side_effect = KeyboardInterrupt()
+
+        selector = PRSelector()
+        prs = [
+            PullRequest(
+                number=41,
+                title="First PR",
+                author="user1",
+                head_ref="feature1",
+                base_ref="main",
+                is_draft=False,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                url="https://github.com/test/repo/pull/41",
+                review_thread_count=1,
+            ),
+            PullRequest(
+                number=42,
+                title="Second PR",
+                author="user2",
+                head_ref="feature2",
+                base_ref="main",
+                is_draft=False,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                url="https://github.com/test/repo/pull/42",
+                review_thread_count=0,
+            ),
+        ]
+
+        result = selector.select_pr(prs)
+        assert result is None
+
+    @patch("click.echo")
+    def test_display_no_prs_message(self, mock_echo) -> None:
+        """Test displaying no PRs message."""
+        selector = PRSelector()
+        selector.display_no_prs_message()
+
+        # Should display message and suggestion
+        assert mock_echo.call_count >= 2
+
+        # Check that appropriate messages were called
+        calls = [str(call_arg) for call_arg in mock_echo.call_args_list]
+        assert any("No open pull requests" in call_str for call_str in calls)
+        assert any("specify a PR number" in call_str for call_str in calls)
+
+    @patch("click.echo")
+    def test_display_auto_selected_pr(self, mock_echo) -> None:
+        """Test displaying auto-selected PR message."""
+        selector = PRSelector()
+        pr = PullRequest(
+            number=42,
+            title="Auto-selected PR",
+            author="testuser",
+            head_ref="feature",
+            base_ref="main",
+            is_draft=False,
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            url="https://github.com/test/repo/pull/42",
+            review_thread_count=2,
+        )
+
+        selector.display_auto_selected_pr(pr)
+
+        # Should display header, PR info, and author/branch info
+        assert mock_echo.call_count >= 3
+
+        # Check that PR information was included
+        calls = [str(call_arg) for call_arg in mock_echo.call_args_list]
+        assert any(
+            "#42" in call_str and "Auto-selected PR" in call_str for call_str in calls
+        )
+        assert any(
+            "testuser" in call_str and "feature" in call_str for call_str in calls
+        )
+
+    @patch("click.echo")
+    def test_display_pr_list_formatting(self, mock_echo) -> None:
+        """Test PR list display formatting with various PR types."""
+        selector = PRSelector()
+        prs = [
+            PullRequest(
+                number=41,
+                title="Regular PR with threads",
+                author="user1",
+                head_ref="feature1",
+                base_ref="main",
+                is_draft=False,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                url="https://github.com/test/repo/pull/41",
+                review_thread_count=3,
+            ),
+            PullRequest(
+                number=42,
+                title="Draft PR without threads",
+                author="user2",
+                head_ref="feature2",
+                base_ref="develop",
+                is_draft=True,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                url="https://github.com/test/repo/pull/42",
+                review_thread_count=0,
+            ),
+        ]
+
+        selector._display_pr_list(prs)
+
+        # Should display each PR with proper formatting
+        calls = [str(call_arg) for call_arg in mock_echo.call_args_list]
+
+        # Check for PR numbers, titles, authors, and branch info
+        assert any(
+            "#41" in call_str and "Regular PR with threads" in call_str
+            for call_str in calls
+        )
+        assert any(
+            "#42" in call_str and "Draft PR without threads" in call_str
+            for call_str in calls
+        )
+        assert any("user1" in call_str and "feature1" in call_str for call_str in calls)
+        assert any("user2" in call_str and "feature2" in call_str for call_str in calls)
+        assert any("develop" in call_str for call_str in calls)
+
+
+class TestPRSelectionResult:
+    """Test the PRSelectionResult class."""
+
+    def test_init_with_selection(self) -> None:
+        """Test initialization with a selected PR."""
+        result = PRSelectionResult(pr_number=42, cancelled=False)
+        assert result.pr_number == 42
+        assert result.cancelled is False
+        assert result.has_selection is True
+        assert result.should_continue is True
+
+    def test_init_cancelled(self) -> None:
+        """Test initialization with cancelled selection."""
+        result = PRSelectionResult(pr_number=None, cancelled=True)
+        assert result.pr_number is None
+        assert result.cancelled is True
+        assert result.has_selection is False
+        assert result.should_continue is False
+
+    def test_init_no_selection(self) -> None:
+        """Test initialization with no selection (no PRs available)."""
+        result = PRSelectionResult(pr_number=None, cancelled=False)
+        assert result.pr_number is None
+        assert result.cancelled is False
+        assert result.has_selection is False
+        assert result.should_continue is False
+
+    def test_has_selection_property(self) -> None:
+        """Test has_selection property."""
+        result_with_selection = PRSelectionResult(pr_number=42)
+        result_without_selection = PRSelectionResult(pr_number=None)
+
+        assert result_with_selection.has_selection is True
+        assert result_without_selection.has_selection is False
+
+    def test_should_continue_property(self) -> None:
+        """Test should_continue property."""
+        # Should continue with valid selection
+        result_continue = PRSelectionResult(pr_number=42, cancelled=False)
+        assert result_continue.should_continue is True
+
+        # Should not continue if cancelled
+        result_cancelled = PRSelectionResult(pr_number=42, cancelled=True)
+        assert result_cancelled.should_continue is False
+
+        # Should not continue if no selection
+        result_no_selection = PRSelectionResult(pr_number=None, cancelled=False)
+        assert result_no_selection.should_continue is False
+
+
+class TestCreatePRSelector:
+    """Test the create_pr_selector factory function."""
+
+    def test_create_pr_selector(self) -> None:
+        """Test factory function creates valid PRSelector instance."""
+        selector = create_pr_selector()
+        assert isinstance(selector, PRSelector)
+        assert selector.formatter is not None
+
+
+class TestPRSelectorIntegration:
+    """Integration tests for PR selector workflows."""
+
+    @patch("click.echo")
+    @patch("click.prompt")
+    def test_complete_selection_workflow(self, mock_prompt, mock_echo) -> None:
+        """Test complete PR selection workflow from display to selection."""
+        mock_prompt.return_value = "1"
+
+        selector = PRSelector()
+        prs = [
+            PullRequest(
+                number=42,
+                title="Test PR for selection",
+                author="testuser",
+                head_ref="feature-branch",
+                base_ref="main",
+                is_draft=False,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                url="https://github.com/test/repo/pull/42",
+                review_thread_count=2,
+            ),
+            PullRequest(
+                number=43,
+                title="Second PR for selection",
+                author="testuser2",
+                head_ref="feature-branch-2",
+                base_ref="main",
+                is_draft=False,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                url="https://github.com/test/repo/pull/43",
+                review_thread_count=1,
+            ),
+        ]
+
+        result = selector.select_pr(prs)
+
+        # Should return the selected PR number
+        assert result == 42
+
+        # Should have displayed the menu and gotten user input
+        mock_prompt.assert_called_once()
+
+        # Should have displayed header, PR list, and confirmation
+        calls = [str(call_arg) for call_arg in mock_echo.call_args_list]
+        assert any("Found 2 open pull request" in call_str for call_str in calls)
+        assert any(
+            "#42" in call_str and "Test PR for selection" in call_str
+            for call_str in calls
+        )
+        assert any("Selected PR #42" in call_str for call_str in calls)
+
+    @patch("click.echo")
+    def test_edge_case_very_long_title(self, mock_echo) -> None:
+        """Test handling of very long PR titles in display."""
+        selector = PRSelector()
+        long_title = "A" * 200  # Very long title
+
+        pr = PullRequest(
+            number=42,
+            title=long_title,
+            author="testuser",
+            head_ref="feature",
+            base_ref="main",
+            is_draft=False,
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            url="https://github.com/test/repo/pull/42",
+            review_thread_count=0,
+        )
+
+        selector._display_pr_list([pr])
+
+        # Should handle long titles gracefully (not crash)
+        assert mock_echo.call_count > 0
+        calls = [str(call_arg) for call_arg in mock_echo.call_args_list]
+        assert any("#42" in call_str for call_str in calls)
+
+    @patch("click.echo")
+    def test_edge_case_special_characters_in_title(self, mock_echo) -> None:
+        """Test handling of special characters in PR titles."""
+        selector = PRSelector()
+
+        pr = PullRequest(
+            number=42,
+            title="PR with émojis 🚀 and spëcial chars & symbols!",
+            author="user-name_123",
+            head_ref="feature/special-chars",
+            base_ref="main",
+            is_draft=False,
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            url="https://github.com/test/repo/pull/42",
+            review_thread_count=0,
+        )
+
+        selector._display_pr_list([pr])
+
+        # Should handle special characters gracefully
+        assert mock_echo.call_count > 0
+        calls = [str(call_arg) for call_arg in mock_echo.call_args_list]
+        assert any("#42" in call_str for call_str in calls)
+        assert any("émojis" in call_str for call_str in calls)


### PR DESCRIPTION
- Introduced a new PRSelector class for interactive selection of pull requests, handling scenarios for no PRs, single PR, and multiple PRs.
- Enhanced FetchService with methods for interactive PR selection and fetching review threads based on selected PR.
- Added comprehensive unit tests for the new PR selection logic and FetchService methods to ensure functionality and reliability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an interactive command-line interface for selecting pull requests, including options for auto-selection and cancellation.
  - Added the ability to fetch review threads after selecting a pull request interactively.

- **Tests**
  - Added comprehensive tests covering PR selection scenarios, user interactions, error handling, and integration flows for the new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->