### PR TITLE
Add format selection utilities for CLI commands

### DIFF
--- a/src/toady/format_selection.py
+++ b/src/toady/format_selection.py
@@ -1,0 +1,246 @@
+"""Format selection utilities for CLI commands.
+
+This module provides utilities for handling format selection in CLI commands,
+including Click options, validation, and formatter instantiation.
+"""
+
+import os
+from typing import Any, Callable, Dict, List, Optional, TypeVar, cast
+
+import click
+
+from .format_interfaces import FormatterError, FormatterFactory
+from .formatters import format_fetch_output
+
+# TypeVar for decorator functions
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+class FormatSelectionError(Exception):
+    """Exception raised when format selection fails."""
+
+    def __init__(self, message: str, available_formats: Optional[List[str]] = None):
+        """Initialize format selection error.
+
+        Args:
+            message: Error message.
+            available_formats: List of available format names.
+        """
+        self.available_formats = available_formats or []
+        super().__init__(message)
+
+
+def get_default_format() -> str:
+    """Get the default format from environment or configuration.
+
+    Returns:
+        Default format name ('json' or 'pretty').
+    """
+    # Check environment variable first
+    default_format = os.environ.get("TOADY_DEFAULT_FORMAT", "").lower()
+
+    if default_format in ["json", "pretty"]:
+        return default_format
+
+    # Default to JSON for programmatic use
+    return "json"
+
+
+def validate_format(format_name: str) -> str:
+    """Validate that the format is available.
+
+    Args:
+        format_name: Name of the format to validate.
+
+    Returns:
+        Validated format name.
+
+    Raises:
+        FormatSelectionError: If format is not available.
+    """
+    available_formats = FormatterFactory.list_formatters()
+
+    if format_name not in available_formats:
+        raise FormatSelectionError(
+            f"Format '{format_name}' is not available. "
+            f"Available formats: {', '.join(available_formats)}",
+            available_formats=available_formats,
+        )
+
+    return format_name
+
+
+def resolve_format_from_options(format_option: Optional[str], pretty_flag: bool) -> str:
+    """Resolve format from command options with backward compatibility.
+
+    Args:
+        format_option: Value from --format option (if provided).
+        pretty_flag: Value from --pretty flag (for backward compatibility).
+
+    Returns:
+        Resolved format name.
+
+    Raises:
+        FormatSelectionError: If format resolution fails.
+    """
+    # If --format is explicitly provided, use it
+    if format_option is not None:
+        return validate_format(format_option)
+
+    # Backward compatibility: if --pretty is used, use pretty format
+    if pretty_flag:
+        return "pretty"
+
+    # Otherwise, use default format
+    return get_default_format()
+
+
+def create_formatter(format_name: str, **options: Any) -> Any:
+    """Create a formatter instance with the given options.
+
+    Args:
+        format_name: Name of the formatter to create.
+        **options: Options to pass to the formatter constructor.
+
+    Returns:
+        Formatter instance.
+
+    Raises:
+        FormatSelectionError: If formatter creation fails.
+    """
+    try:
+        return FormatterFactory.create(format_name, **options)
+    except FormatterError as e:
+        raise FormatSelectionError(
+            f"Failed to create formatter '{format_name}': {e}"
+        ) from e
+
+
+def create_format_option(**kwargs: Any) -> Callable[[F], F]:
+    """Create a Click option for format selection.
+
+    Args:
+        **kwargs: Additional arguments for the Click option.
+
+    Returns:
+        Click option decorator.
+    """
+    available_formats = FormatterFactory.list_formatters()
+    choices = available_formats if available_formats else ["json", "pretty"]
+
+    default_kwargs = {
+        "type": click.Choice(choices, case_sensitive=False),
+        "help": (
+            f"Output format ({', '.join(choices)}). "
+            "Default can be set with TOADY_DEFAULT_FORMAT environment variable."
+        ),
+        "metavar": f"{'|'.join(choices)}",
+    }
+    default_kwargs.update(kwargs)
+
+    return cast(Callable[[F], F], click.option("--format", **default_kwargs))  # type: ignore[call-overload]
+
+
+def create_legacy_pretty_option(**kwargs: Any) -> Callable[[F], F]:
+    """Create a Click option for legacy --pretty flag.
+
+    Args:
+        **kwargs: Additional arguments for the Click option.
+
+    Returns:
+        Click option decorator.
+    """
+    default_kwargs = {
+        "is_flag": True,
+        "help": (
+            "Output in human-readable format instead of JSON "
+            "(deprecated, use --format pretty)"
+        ),
+    }
+    default_kwargs.update(kwargs)
+
+    return cast(Callable[[F], F], click.option("--pretty", **default_kwargs))  # type: ignore[call-overload]
+
+
+# Format-specific output functions
+
+
+def format_threads_output(threads: Any, format_name: str, **kwargs: Any) -> None:
+    """Format and output threads using the specified format.
+
+    Args:
+        threads: List of thread objects to format.
+        format_name: Name of the format to use.
+        **kwargs: Additional options for formatting.
+    """
+    if format_name == "json":
+        # Use existing JSON formatting logic
+        format_fetch_output(threads=threads, pretty=False, **kwargs)
+    elif format_name == "pretty":
+        # Use existing pretty formatting logic
+        format_fetch_output(threads=threads, pretty=True, **kwargs)
+    else:
+        # Use new formatter interface for other formats
+        formatter = create_formatter(format_name)
+        output = formatter.format_threads(threads)
+        click.echo(output)
+
+
+def format_object_output(obj: Any, format_name: str) -> None:
+    """Format and output an object using the specified format.
+
+    Args:
+        obj: Object to format.
+        format_name: Name of the format to use.
+    """
+    if format_name == "json":
+        import json
+
+        click.echo(json.dumps(obj, indent=2))
+    else:
+        # Use formatter interface
+        formatter = create_formatter(format_name)
+        output = formatter.format_object(obj)
+        click.echo(output)
+
+
+def format_success_message(
+    message: str, format_name: str, details: Optional[Dict[str, Any]] = None
+) -> None:
+    """Format and output a success message.
+
+    Args:
+        message: Success message text.
+        format_name: Name of the format to use.
+        details: Optional additional details.
+    """
+    if format_name == "json":
+        import json
+
+        success_data = {"success": True, "message": message}
+        if details:
+            success_data["details"] = details
+        click.echo(json.dumps(success_data, indent=2))
+    else:
+        # Use formatter interface
+        formatter = create_formatter(format_name)
+        output = formatter.format_success_message(message, details)
+        click.echo(output)
+
+
+def format_error_message(error: Dict[str, Any], format_name: str) -> None:
+    """Format and output an error message.
+
+    Args:
+        error: Error dictionary with error details.
+        format_name: Name of the format to use.
+    """
+    if format_name == "json":
+        import json
+
+        click.echo(json.dumps(error, indent=2), err=True)
+    else:
+        # Use formatter interface
+        formatter = create_formatter(format_name)
+        output = formatter.format_error(error)
+        click.echo(output, err=True)

--- a/tests/integration/cli/test_format_selection_cli.py
+++ b/tests/integration/cli/test_format_selection_cli.py
@@ -1,0 +1,288 @@
+"""Integration tests for format selection in CLI commands."""
+
+import json
+from unittest.mock import Mock, patch
+
+from click.testing import CliRunner
+
+from toady.commands.fetch import fetch
+from toady.commands.reply import reply
+from toady.commands.resolve import resolve
+
+
+class TestFetchCommandFormatSelection:
+    """Test format selection in fetch command."""
+
+    @patch("toady.commands.fetch.FetchService")
+    def test_fetch_with_format_json(self, mock_fetch_service):
+        """Test fetch command with --format json."""
+        # Mock the service to return empty threads
+        mock_service_instance = Mock()
+        mock_service_instance.fetch_review_threads_with_pr_selection.return_value = (
+            [],
+            123,
+        )
+        mock_fetch_service.return_value = mock_service_instance
+
+        runner = CliRunner()
+        result = runner.invoke(fetch, ["--pr", "123", "--format", "json"])
+
+        assert result.exit_code == 0
+        # Output should be JSON
+        assert result.output.strip() == "[]"
+
+    @patch("toady.commands.fetch.FetchService")
+    def test_fetch_with_format_pretty(self, mock_fetch_service):
+        """Test fetch command with --format pretty."""
+        # Mock the service to return empty threads
+        mock_service_instance = Mock()
+        mock_service_instance.fetch_review_threads_with_pr_selection.return_value = (
+            [],
+            123,
+        )
+        mock_fetch_service.return_value = mock_service_instance
+
+        runner = CliRunner()
+        result = runner.invoke(fetch, ["--pr", "123", "--format", "pretty"])
+
+        assert result.exit_code == 0
+        # Output should contain pretty format indicators
+        assert "No review threads found" in result.output or "threads" in result.output
+
+    @patch("toady.commands.fetch.FetchService")
+    def test_fetch_with_pretty_flag_backward_compatibility(self, mock_fetch_service):
+        """Test fetch command with legacy --pretty flag."""
+        # Mock the service to return empty threads
+        mock_service_instance = Mock()
+        mock_service_instance.fetch_review_threads_with_pr_selection.return_value = (
+            [],
+            123,
+        )
+        mock_fetch_service.return_value = mock_service_instance
+
+        runner = CliRunner()
+        result = runner.invoke(fetch, ["--pr", "123", "--pretty"])
+
+        assert result.exit_code == 0
+        # Should behave like --format pretty
+        assert "No review threads found" in result.output or "threads" in result.output
+
+    def test_fetch_with_invalid_format(self):
+        """Test fetch command with invalid format."""
+        runner = CliRunner()
+        result = runner.invoke(fetch, ["--pr", "123", "--format", "invalid"])
+
+        assert result.exit_code == 2  # Click returns 2 for invalid option values
+        assert "Error:" in result.output
+        assert "invalid" in result.output
+
+
+class TestReplyCommandFormatSelection:
+    """Test format selection in reply command."""
+
+    @patch("toady.commands.reply.ReplyService")
+    def test_reply_with_format_json(self, mock_reply_service):
+        """Test reply command with --format json."""
+        # Mock the service
+        mock_service_instance = Mock()
+        mock_service_instance.post_reply.return_value = {
+            "reply_id": "123",
+            "reply_url": "https://example.com",
+            "created_at": "2024-01-01T00:00:00Z",
+            "author": "testuser",
+        }
+        mock_reply_service.return_value = mock_service_instance
+
+        runner = CliRunner()
+        result = runner.invoke(
+            reply,
+            ["--reply-to-id", "123456789", "--body", "Test reply", "--format", "json"],
+        )
+
+        assert result.exit_code == 0
+        # Output should be valid JSON
+        output_data = json.loads(result.output)
+        assert output_data["success"] is True
+        assert output_data["reply_posted"] is True
+
+    @patch("toady.commands.reply.ReplyService")
+    def test_reply_with_format_pretty(self, mock_reply_service):
+        """Test reply command with --format pretty."""
+        # Mock the service
+        mock_service_instance = Mock()
+        mock_service_instance.post_reply.return_value = {
+            "reply_id": "123",
+            "reply_url": "https://example.com",
+            "created_at": "2024-01-01T00:00:00Z",
+            "author": "testuser",
+        }
+        mock_reply_service.return_value = mock_service_instance
+
+        runner = CliRunner()
+        result = runner.invoke(
+            reply,
+            [
+                "--reply-to-id",
+                "123456789",
+                "--body",
+                "Test reply",
+                "--format",
+                "pretty",
+            ],
+        )
+
+        assert result.exit_code == 0
+        # Output should contain pretty format indicators
+        assert "✅" in result.output or "Reply posted" in result.output
+
+
+class TestResolveCommandFormatSelection:
+    """Test format selection in resolve command."""
+
+    @patch("toady.commands.resolve.ResolveService")
+    def test_resolve_with_format_json(self, mock_resolve_service):
+        """Test resolve command with --format json."""
+        # Mock the service
+        mock_service_instance = Mock()
+        mock_service_instance.resolve_thread.return_value = {
+            "thread_id": "123456789",
+            "action": "resolve",
+            "success": True,
+            "is_resolved": "true",
+            "thread_url": "https://example.com",
+        }
+        mock_resolve_service.return_value = mock_service_instance
+
+        runner = CliRunner()
+        result = runner.invoke(
+            resolve, ["--thread-id", "123456789", "--format", "json"]
+        )
+
+        assert result.exit_code == 0
+        # Output should be valid JSON
+        output_data = json.loads(result.output)
+        assert output_data["success"] is True
+
+    @patch("toady.commands.resolve.ResolveService")
+    def test_resolve_with_format_pretty(self, mock_resolve_service):
+        """Test resolve command with --format pretty."""
+        # Mock the service
+        mock_service_instance = Mock()
+        mock_service_instance.resolve_thread.return_value = {
+            "thread_id": "123456789",
+            "action": "resolve",
+            "success": True,
+            "is_resolved": "true",
+            "thread_url": "https://example.com",
+        }
+        mock_resolve_service.return_value = mock_service_instance
+
+        runner = CliRunner()
+        result = runner.invoke(
+            resolve, ["--thread-id", "123456789", "--format", "pretty"]
+        )
+
+        assert result.exit_code == 0
+        # Output should contain pretty format indicators
+        assert "✅" in result.output or "Resolved" in result.output
+
+
+class TestEnvironmentVariableIntegration:
+    """Test environment variable integration in CLI commands."""
+
+    @patch.dict("os.environ", {"TOADY_DEFAULT_FORMAT": "pretty"})
+    @patch("toady.commands.fetch.FetchService")
+    def test_environment_variable_default_format(self, mock_fetch_service):
+        """Test that environment variable sets default format."""
+        # Mock the service to return empty threads
+        mock_service_instance = Mock()
+        mock_service_instance.fetch_review_threads_with_pr_selection.return_value = (
+            [],
+            123,
+        )
+        mock_fetch_service.return_value = mock_service_instance
+
+        runner = CliRunner()
+        # No format specified - should use env var
+        result = runner.invoke(fetch, ["--pr", "123"])
+
+        assert result.exit_code == 0
+        # Should use pretty format due to env var
+        assert "No review threads found" in result.output or "threads" in result.output
+
+    @patch.dict("os.environ", {"TOADY_DEFAULT_FORMAT": "pretty"})
+    @patch("toady.commands.fetch.FetchService")
+    def test_explicit_format_overrides_environment(self, mock_fetch_service):
+        """Test that explicit format overrides environment variable."""
+        # Mock the service to return empty threads
+        mock_service_instance = Mock()
+        mock_service_instance.fetch_review_threads_with_pr_selection.return_value = (
+            [],
+            123,
+        )
+        mock_fetch_service.return_value = mock_service_instance
+
+        runner = CliRunner()
+        # Explicit format should override env var
+        result = runner.invoke(fetch, ["--pr", "123", "--format", "json"])
+
+        assert result.exit_code == 0
+        # Should use JSON format despite env var setting pretty
+        assert result.output.strip() == "[]"
+
+
+class TestFormatOptionValidation:
+    """Test format option validation in CLI commands."""
+
+    def test_invalid_format_option_fetch(self):
+        """Test invalid format option in fetch command."""
+        runner = CliRunner()
+        result = runner.invoke(fetch, ["--format", "invalid"])
+
+        # Should fail with validation error
+        assert result.exit_code != 0
+        assert "invalid" in result.output.lower()
+
+    def test_invalid_format_option_reply(self):
+        """Test invalid format option in reply command."""
+        runner = CliRunner()
+        result = runner.invoke(
+            reply,
+            ["--reply-to-id", "123456789", "--body", "Test", "--format", "invalid"],
+        )
+
+        # Should fail with validation error
+        assert result.exit_code != 0
+
+    def test_invalid_format_option_resolve(self):
+        """Test invalid format option in resolve command."""
+        runner = CliRunner()
+        result = runner.invoke(
+            resolve, ["--thread-id", "123456789", "--format", "invalid"]
+        )
+
+        # Should fail with validation error
+        assert result.exit_code != 0
+
+
+class TestMixedFormatOptions:
+    """Test behavior when both --format and --pretty are specified."""
+
+    @patch("toady.commands.fetch.FetchService")
+    def test_format_option_takes_precedence_over_pretty(self, mock_fetch_service):
+        """Test that --format takes precedence over --pretty."""
+        # Mock the service to return empty threads
+        mock_service_instance = Mock()
+        mock_service_instance.fetch_review_threads_with_pr_selection.return_value = (
+            [],
+            123,
+        )
+        mock_fetch_service.return_value = mock_service_instance
+
+        runner = CliRunner()
+        # Both options specified - format should take precedence
+        result = runner.invoke(fetch, ["--pr", "123", "--format", "json", "--pretty"])
+
+        assert result.exit_code == 0
+        # Should use JSON format despite --pretty flag
+        assert result.output.strip() == "[]"

--- a/tests/unit/test_format_selection.py
+++ b/tests/unit/test_format_selection.py
@@ -1,0 +1,207 @@
+"""Tests for format selection utilities."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from toady.format_selection import (
+    FormatSelectionError,
+    create_formatter,
+    get_default_format,
+    resolve_format_from_options,
+    validate_format,
+)
+
+
+class TestGetDefaultFormat:
+    """Test default format retrieval."""
+
+    def test_default_format_from_env_json(self):
+        """Test getting JSON format from environment."""
+        with patch.dict(os.environ, {"TOADY_DEFAULT_FORMAT": "json"}):
+            assert get_default_format() == "json"
+
+    def test_default_format_from_env_pretty(self):
+        """Test getting pretty format from environment."""
+        with patch.dict(os.environ, {"TOADY_DEFAULT_FORMAT": "pretty"}):
+            assert get_default_format() == "pretty"
+
+    def test_default_format_from_env_uppercase(self):
+        """Test environment variable is case insensitive."""
+        with patch.dict(os.environ, {"TOADY_DEFAULT_FORMAT": "JSON"}):
+            assert get_default_format() == "json"
+
+    def test_default_format_invalid_env(self):
+        """Test invalid environment value falls back to default."""
+        with patch.dict(os.environ, {"TOADY_DEFAULT_FORMAT": "invalid"}):
+            assert get_default_format() == "json"
+
+    def test_default_format_no_env(self):
+        """Test default when no environment variable is set."""
+        with patch.dict(os.environ, {}, clear=True):
+            if "TOADY_DEFAULT_FORMAT" in os.environ:
+                del os.environ["TOADY_DEFAULT_FORMAT"]
+            assert get_default_format() == "json"
+
+
+class TestValidateFormat:
+    """Test format validation."""
+
+    def test_validate_json_format(self):
+        """Test validating JSON format."""
+        result = validate_format("json")
+        assert result == "json"
+
+    def test_validate_pretty_format(self):
+        """Test validating pretty format."""
+        result = validate_format("pretty")
+        assert result == "pretty"
+
+    def test_validate_invalid_format(self):
+        """Test validating invalid format raises error."""
+        with pytest.raises(FormatSelectionError) as exc_info:
+            validate_format("invalid")
+
+        assert "Format 'invalid' is not available" in str(exc_info.value)
+        assert "json" in str(exc_info.value)
+        assert "pretty" in str(exc_info.value)
+
+
+class TestResolveFormatFromOptions:
+    """Test format resolution from command options."""
+
+    def test_explicit_format_option_json(self):
+        """Test explicit format option takes precedence."""
+        result = resolve_format_from_options("json", True)
+        assert result == "json"
+
+    def test_explicit_format_option_pretty(self):
+        """Test explicit format option takes precedence."""
+        result = resolve_format_from_options("pretty", False)
+        assert result == "pretty"
+
+    def test_pretty_flag_backward_compatibility(self):
+        """Test --pretty flag backward compatibility."""
+        result = resolve_format_from_options(None, True)
+        assert result == "pretty"
+
+    def test_no_pretty_flag_uses_default(self):
+        """Test no pretty flag uses default format."""
+        with patch("toady.format_selection.get_default_format", return_value="json"):
+            result = resolve_format_from_options(None, False)
+            assert result == "json"
+
+    def test_invalid_explicit_format(self):
+        """Test invalid explicit format raises error."""
+        with pytest.raises(FormatSelectionError):
+            resolve_format_from_options("invalid", False)
+
+
+class TestCreateFormatter:
+    """Test formatter creation."""
+
+    def test_create_json_formatter(self):
+        """Test creating JSON formatter."""
+        formatter = create_formatter("json")
+        assert formatter is not None
+        # Should have the expected interface methods
+        assert hasattr(formatter, "format_threads")
+        assert hasattr(formatter, "format_comments")
+        assert hasattr(formatter, "format_object")
+
+    def test_create_pretty_formatter(self):
+        """Test creating pretty formatter."""
+        formatter = create_formatter("pretty")
+        assert formatter is not None
+        # Should have the expected interface methods
+        assert hasattr(formatter, "format_threads")
+        assert hasattr(formatter, "format_comments")
+        assert hasattr(formatter, "format_object")
+
+    def test_create_formatter_with_options(self):
+        """Test creating formatter with options."""
+        formatter = create_formatter("json", indent=4, sort_keys=True)
+        assert formatter is not None
+
+    def test_create_invalid_formatter(self):
+        """Test creating invalid formatter raises error."""
+        with pytest.raises(FormatSelectionError) as exc_info:
+            create_formatter("invalid")
+
+        assert "Failed to create formatter 'invalid'" in str(exc_info.value)
+
+
+class TestFormatSelectionError:
+    """Test FormatSelectionError exception."""
+
+    def test_basic_error(self):
+        """Test basic error creation."""
+        error = FormatSelectionError("Test message")
+        assert str(error) == "Test message"
+        assert error.available_formats == []
+
+    def test_error_with_available_formats(self):
+        """Test error with available formats."""
+        formats = ["json", "pretty"]
+        error = FormatSelectionError("Test message", available_formats=formats)
+        assert str(error) == "Test message"
+        assert error.available_formats == formats
+
+
+class TestFormatSelectionIntegration:
+    """Integration tests for format selection."""
+
+    def test_end_to_end_json_selection(self):
+        """Test complete JSON format selection workflow."""
+        # Simulate --format json
+        format_name = resolve_format_from_options("json", False)
+        formatter = create_formatter(format_name)
+
+        # Test basic functionality
+        result = formatter.format_object({"test": "data"})
+        assert "test" in result
+        assert "data" in result
+
+    def test_end_to_end_pretty_selection(self):
+        """Test complete pretty format selection workflow."""
+        # Simulate --format pretty
+        format_name = resolve_format_from_options("pretty", False)
+        formatter = create_formatter(format_name)
+
+        # Test basic functionality
+        result = formatter.format_object({"test": "data"})
+        assert "test" in result
+        assert "data" in result
+
+    def test_backward_compatibility_pretty_flag(self):
+        """Test backward compatibility with --pretty flag."""
+        # Simulate --pretty flag (no --format option)
+        format_name = resolve_format_from_options(None, True)
+        assert format_name == "pretty"
+
+        formatter = create_formatter(format_name)
+        result = formatter.format_object({"test": "data"})
+        assert "test" in result
+
+    def test_environment_variable_integration(self):
+        """Test environment variable integration."""
+        with patch.dict(os.environ, {"TOADY_DEFAULT_FORMAT": "pretty"}):
+            # No explicit options - should use env var
+            format_name = resolve_format_from_options(None, False)
+            assert format_name == "pretty"
+
+    def test_option_precedence_order(self):
+        """Test option precedence: explicit > pretty flag > env > default."""
+        with patch.dict(os.environ, {"TOADY_DEFAULT_FORMAT": "pretty"}):
+            # Explicit format should override everything
+            format_name = resolve_format_from_options("json", True)
+            assert format_name == "json"
+
+            # Pretty flag should override env
+            format_name = resolve_format_from_options(None, True)
+            assert format_name == "pretty"
+
+            # Env should be used when no options given
+            format_name = resolve_format_from_options(None, False)
+            assert format_name == "pretty"


### PR DESCRIPTION
- Introduced a new module `format_selection.py` to handle format selection for CLI commands, including options for JSON and pretty formats.
- Implemented functions for validating formats, resolving formats from command options, and creating formatters.
- Updated existing commands (`fetch`, `reply`, `resolve`) to utilize the new format selection system, enhancing output flexibility.
- Added integration and unit tests to ensure proper functionality and backward compatibility with the legacy `--pretty` flag.