### PR TITLE
Update license configuration and package inclusion in pyproject.toml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,42 @@
+# Include license and documentation
+include LICENSE
+include README.md
+include CHANGELOG.md
+
+# Include configuration for packaging
+include pyproject.toml
+
+# Include type hints marker
+include src/toady/py.typed
+
+# Exclude development and configuration files
+exclude .env.example
+exclude .pre-commit-config.yaml
+exclude Makefile
+exclude mypy.ini
+exclude pytest.ini
+exclude requirements.txt
+exclude uv.lock
+
+# Exclude development directories
+recursive-exclude .cursor *
+recursive-exclude .roo *
+recursive-exclude .taskmaster *
+recursive-exclude tests *
+recursive-exclude scripts *
+recursive-exclude docs *
+recursive-exclude htmlcov *
+recursive-exclude build *
+recursive-exclude dist *
+
+# Exclude cache and temporary files
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude *.orig
+global-exclude *.rej
+global-exclude *~
+global-exclude __pycache__
+global-exclude .pytest_cache
+global-exclude .coverage
+global-exclude coverage.xml
+global-exclude coverage.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ name = "toady-cli"
 version = "0.1.0"
 description = "A CLI tool for managing GitHub PR code reviews efficiently"
 readme = "README.md"
-license = {file = "LICENSE"}
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [
     {name = "Tony Blank", email = "guillotine@lawnfucker.com"},
 ]
@@ -18,7 +19,6 @@ keywords = ["github", "cli", "code-review", "pull-request", "automation"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
@@ -97,6 +97,7 @@ toady = "toady.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+include = ["toady*"]
 
 [tool.setuptools.package-data]
 toady = ["py.typed"]


### PR DESCRIPTION
- Changed the license format from a file reference to a string for clarity and added a separate license-files entry.
- Removed the OSI Approved classifier for the MIT License to simplify the classifiers section.
- Updated the package inclusion settings to explicitly include all relevant packages under the 'toady' namespace.

These changes aim to improve the clarity of the project configuration and ensure proper package inclusion during distribution.